### PR TITLE
fix: Fix template references to the newly created assets module

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/content-main.js
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/content-main.js
@@ -92,7 +92,7 @@
                     title: data.store.name,
                     subtitle: 'content.blades.pages-list.subtitle-pages',
                     controller: 'virtoCommerce.contentModule.pagesListController',
-                    template: '$(Platform)/Scripts/app/assets/blades/asset-list.tpl.html'
+                    template: 'Modules/$(VirtoCommerce.Assets)/Scripts/blades/asset-list.tpl.html'
                 };
                 bladeNavigationService.showBlade(newBlade, blade);
             };
@@ -121,7 +121,7 @@
                     title: data.store.name,
                     subtitle: 'content.blades.pages-list.subtitle-blogs',
                     controller: 'virtoCommerce.contentModule.pagesListController',
-                    template: '$(Platform)/Scripts/app/assets/blades/asset-list.tpl.html'
+                    template: 'Modules/$(VirtoCommerce.Assets)/Scripts/blades/asset-list.tpl.html'
                 };
                 bladeNavigationService.showBlade(newBlade, blade);
             };
@@ -207,7 +207,7 @@
                     currentEntity: { name: data.activeThemeName, url: data.activeThemeURL },
                     subtitle: 'content.blades.asset-list.subtitle',
                     controller: 'virtoCommerce.contentModule.assetListController',
-                    template: '$(Platform)/Scripts/app/assets/blades/asset-list.tpl.html'
+                    template: 'Modules/$(VirtoCommerce.Assets)/Scripts/blades/asset-list.tpl.html'
                 };
                 bladeNavigationService.showBlade(newBlade, blade);
             };

--- a/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/pages/pages-list.js
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/pages/pages-list.js
@@ -261,7 +261,7 @@
                         currentEntityId: blade.currentEntity.url,
                         title: 'platform.blades.asset-upload.title',
                         controller: 'virtoCommerce.contentModule.assetUploadController',
-                        template: '$(Platform)/Scripts/app/assets/blades/asset-upload.tpl.html'
+                        template: 'Modules/$(VirtoCommerce.Assets)/Scripts/blades/asset-upload.tpl.html'
                     };
                     bladeNavigationService.showBlade(newBlade, blade);
                 },


### PR DESCRIPTION
The assets functionality declared obsolete in the platform and will be removed soon.
This fix makes references to assets angular templates to the newly created assets module in order to continue pagebuilder working after removing assets functionality from the platform.