### PR TITLE
VCST-4502: Add filter groups by keyword

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Data/Services/GroupedPageSearchService.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Data/Services/GroupedPageSearchService.cs
@@ -29,6 +29,11 @@ namespace VirtoCommerce.PageBuilderModule.Data.Services
                 query = query.Where(x => x.StoreId == criteria.StoreId);
             }
 
+            if (!criteria.Keyword.IsNullOrEmpty())
+            {
+                query = query.Where(x => x.Name.Contains(criteria.Keyword) || x.Permalink.Contains(criteria.Keyword));
+            }
+
             if (!string.IsNullOrEmpty(criteria.Statuses))
             {
                 var statuses = criteria.Statuses.Split(',', StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4502
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.832.0-pr-93-93c6.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces keyword filtering to improve grouped page search precision.
> 
> - In `GroupedPageSearchService`, applies `criteria.Keyword` to filter groups where `Name` or `Permalink` contains the keyword
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93c65f91f40fd06af9c2f82a28a5a9410ec188d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->