### PR TITLE
VP-9015: Merge branch 'release/3.835.0'

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/pages/edit-page.js
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/pages/edit-page.js
@@ -164,8 +164,8 @@ angular.module('virtoCommerce.pageBuilderModule')
                             var showPreview = function (storeUrl) {
                                 storeUrl = (storeUrl || blade.storeUrl).replace(/\/$/, '');
                                 if (storeUrl) {
-                                    var path = generatePath();
-                                    window.open(storeUrl + '/pages?path=' + path, '_blank');
+                                    var documentId = filesDraftService.getDocumentId(blade, true);
+                                    window.open(`${storeUrl}/designer-preview?pageId=${encodeURIComponent(documentId)}`, '_blank');
                                 } else {
                                     var dialog = {
                                         id: "noUrlInStore",
@@ -307,8 +307,7 @@ angular.module('virtoCommerce.pageBuilderModule')
             }
 
             function getSearchDocumentInfo() {
-                var relativeUrl = undraftUrl(blade.currentEntity.relativeUrl);
-                var documentId = btoa(`${blade.storeId}::${blade.contentType}::${relativeUrl}`).replaceAll('=', '-');
+                var documentId = filesDraftService.getDocumentId(blade, false);
                 var documentType = 'ContentFile';
                 return { documentType: documentType, documentId: documentId };
             }
@@ -340,18 +339,11 @@ angular.module('virtoCommerce.pageBuilderModule')
                 return isDirty() && formScope && formScope.$valid;
             }
 
-            function generatePath() {
-                // need to return path relative to the root folder
-                //return blade.currentEntity.settings.permalink
-                //    ? '/' + blade.currentEntity.settings.permalink
-                //    : blade.currentEntity.relativeUrl;
-                return blade.currentEntity.relativeUrl;
-            }
-
             function runDesigner() {
                 if (blade.designerUrl) {
                     var relativeUrl = filesDraftService.getDraftFileName(blade);
-                    window.open(blade.designerUrl + '?storeId=' + blade.storeId + '#/pages?type=' + blade.contentType + '&path=' + relativeUrl, '_blank');
+                    var previewId = filesDraftService.getDocumentId(blade, true);
+                    window.open(`${blade.designerUrl}?storeId=${blade.storeId}#/pages?type=${blade.contentType}&path=${relativeUrl}&previewId=${encodeURIComponent(previewId)}`, '_blank');
                 } else {
                     var dialog = {
                         id: "noUrlInStore",


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1001.0-pr-104-312a.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how page preview URLs and search index document IDs are generated, which could break existing preview links or cause mismatches with already-indexed documents. Scope is limited to the page editor blade but touches preview/designer navigation and search index access paths.
> 
> **Overview**
> Updates the page editor’s preview and designer launch flows to use `filesDraftService.getDocumentId(...)` instead of building paths/IDs inline.
> 
> Preview now opens `${storeUrl}/designer-preview?pageId=...` (with URL-encoded document ID), the designer URL gains a `previewId` query param, and search index lookups use the same centralized document ID generation. The unused `generatePath()` helper is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 312a3ac5b2a1f976fe8f5d3be8d3c201d7627ebb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->