### PR TITLE
VCST-4950: Disable clone button after click

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/pages/PageDetails.vue
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/pages/PageDetails.vue
@@ -323,8 +323,9 @@ const bladeToolbar = computed((): IBladeToolbar[] => [
     id: "clonePage",
     icon: "material-content_copy",
     title: t("PAGE_BUILDER.PAGES.DETAILS.TOOLBAR.CLONE"),
-    disabled: !props.param || isReadOnly.value,
+    disabled: !props.param || isReadOnly.value || loading.value,
     clickHandler: async () => {
+      if (loading.value) return;
       const cloned = await clonePage();
       if (cloned?.id) {
         notification.success(t("PAGE_BUILDER.PAGES.ALERTS.CLONE_SUCCESS"));


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4950
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1005.0-pr-125-d0b8.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/UX guard change that only affects the clone button’s enabled state and click handling; minimal behavioral impact outside preventing duplicate actions.
> 
> **Overview**
> Prevents duplicate page cloning in `PageDetails.vue` by disabling the **Clone** toolbar button while the blade is in `loading` state.
> 
> Adds a defensive early-return in the clone click handler so repeated clicks during loading are ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b84683b046b89c9ad6a61afa01fc108126b560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->