### PR TITLE
VCST-4951: Toast notifications

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/components/pagesList.vue
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/components/pagesList.vue
@@ -72,7 +72,7 @@
 import { ref, Ref, computed, watch, onMounted, readonly } from "vue";
 import { useI18n } from "vue-i18n";
 import { debounce } from "lodash-es";
-import { ITableColumns, useTableSort, useBladeNavigation, usePopup, IActionBuilderResult } from "@vc-shell/framework";
+import { ITableColumns, useTableSort, useBladeNavigation, usePopup, IActionBuilderResult, notification } from "@vc-shell/framework";
 import { GroupedPageBuilderPage } from "../../../api_client/virtocommerce.pagebuildermodule";
 import { PageLifecycleFilters, usePageBuilderList, useUrlParams, refreshMenuBadges } from "../composables";
 import { parseImportFile } from "../composables/usePageContentApi";
@@ -248,6 +248,7 @@ async function onFileSelected(event: Event) {
   input.value = "";
 
   const importData = await parseImportFile(file);
+  notification.success(t("PAGE_BUILDER.PAGES.ALERTS.LOAD_CONTENT_SUCCESS"));
 
   openBlade({
     blade: { name: "PageDetails" },

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/locales/en.json
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/locales/en.json
@@ -113,7 +113,12 @@
         },
         "UNPUBLISH_WITH_DRAFT": "Can't unpublish a page that has changes.",
         "DOWNLOAD_SUCCESS": "Content saved to file successfully",
-        "CLONE_SUCCESS": "Page cloned successfully"
+        "CLONE_SUCCESS": "Page cloned successfully",
+        "LOAD_CONTENT_SUCCESS": "Content loaded successfully",
+        "SAVE_SUCCESS": "Page saved successfully",
+        "PUBLISH_SUCCESS": "Page published successfully",
+        "UNPUBLISH_SUCCESS": "Page unpublished successfully",
+        "DELETE_SUCCESS": "Page archived successfully"
       }
     },
     "STATUS": {

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/pages/PageDetails.vue
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/pages/PageDetails.vue
@@ -288,7 +288,7 @@ const bladeToolbar = computed((): IBladeToolbar[] => [
     id: "delete",
     icon: "material-delete",
     title: t("PAGE_BUILDER.PAGES.DETAILS.TOOLBAR.DELETE"),
-    disabled: isReadOnly.value,
+    disabled: !props.param || isReadOnly.value,
     clickHandler: async () => {
       if (await showConfirmation(t("PAGE_BUILDER.PAGES.ALERTS.DELETE"))) {
         await deleteGroup();

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/pages/PageDetails.vue
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-shell/src/modules/page-builder/pages/PageDetails.vue
@@ -281,6 +281,7 @@ const bladeToolbar = computed((): IBladeToolbar[] => [
     disabled: !isModified.value || isReadOnly.value || !meta.value.valid,
     clickHandler: async () => {
       await handleSave();
+      notification.success(t("PAGE_BUILDER.PAGES.ALERTS.SAVE_SUCCESS"));
     },
   },
   {
@@ -291,6 +292,7 @@ const bladeToolbar = computed((): IBladeToolbar[] => [
     clickHandler: async () => {
       if (await showConfirmation(t("PAGE_BUILDER.PAGES.ALERTS.DELETE"))) {
         await deleteGroup();
+        notification.success(t("PAGE_BUILDER.PAGES.ALERTS.DELETE_SUCCESS"));
         emit("parent:call", { method: "reload" });
         emit("close:blade");
       }
@@ -341,6 +343,7 @@ const bladeToolbar = computed((): IBladeToolbar[] => [
     disabled: isReadOnly.value || !meta.value.valid || isModified.value,
     clickHandler: async () => {
       await publishGroup();
+      notification.success(t("PAGE_BUILDER.PAGES.ALERTS.PUBLISH_SUCCESS"));
       emit("parent:call", { method: "reload" });
     },
   },
@@ -352,6 +355,7 @@ const bladeToolbar = computed((): IBladeToolbar[] => [
     disabled: isReadOnly.value,
     clickHandler: async () => {
       await unpublishGroup();
+      notification.success(t("PAGE_BUILDER.PAGES.ALERTS.UNPUBLISH_SUCCESS"));
       emit("parent:call", { method: "reload" });
     },
   },

--- a/src/VirtoCommerce.PageBuilderModule.Web/Controllers/Api/PageBuilderPageController.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Controllers/Api/PageBuilderPageController.cs
@@ -304,7 +304,7 @@ public class PageBuilderPageController(
             return;
         }
 
-        var pageId = group.Pages.Where(x => (draft && x.Status == Draft) || x.Status == Published)
+        var pageId = group.Pages.Where(x => (draft && x.Status == Draft) || x.Status == Published || x.Status == Archived)
             .OrderByDescending(x => x.ModifiedDate).Select(x => x.Id).FirstOrDefault();
         if (pageId == null)
         {


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4951
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1006.0-pr-126-0192.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI feedback changes, but it also modifies server-side content selection logic for downloads to include archived pages, which could change what content is returned in edge cases.
> 
> **Overview**
> Adds **success toast notifications** for key Page Builder actions: loading content from file (`pagesList.vue`), and saving/publishing/unpublishing/archiving from the details blade (`PageDetails.vue`), backed by new i18n strings in `locales/en.json`.
> 
> Updates the backend `GET api/page-builder-pages/grouped/{groupId}/content` endpoint to also select content from **archived** pages when resolving which page version to stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 019268dab0743aa89345aacf06d4ad8e208c3e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->