### PR TITLE
VCST-4848: Add module.keep file to include VirtoCommerce.Pages.Core.dll

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Module CI
 
 on:
@@ -53,20 +53,18 @@ jobs:
       version: ${{ steps.artifact_ver.outputs.shortVersion }}
       moduleId: ${{ steps.artifact_ver.outputs.moduleId }}
       matrix: ${{ steps.deployment-matrix.outputs.matrix }}
-      run-e2e: ${{ steps.run-e2e.outputs.result }}
-      run-ui-tests: ${{ steps.run-ui-tests.outputs.result }}
       deployment-folder-exists: ${{ steps.check_deployment_folder.outputs.exists }}
       requiredModulesListUrl: ${{ steps.extract_required_modules_list_url_from_pr.outputs.url }}
 
     steps:
 
-      - name: Set up Node 20
-        uses: actions/setup-node@v4
+      - name: Set up Node 24
+        uses: actions/setup-node@v6
         with:
-            node-version: '20'
+            node-version: '24'
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -76,7 +74,7 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -211,18 +209,6 @@ jobs:
           deployConfigPath: '.deployment/module/cloudDeploy.json'
           releaseBranch: 'master'
 
-      - name: Check commit message for version number
-        id: run-e2e
-        env:
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-        run: |
-          if [[ "$COMMIT_MESSAGE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]];
-          then
-            echo "result=false" >> $GITHUB_OUTPUT
-          else
-            echo "result=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Extract required modules list URL from the pull request description
         if: ${{ github.event_name == 'pull_request' }}
         id: extract_required_modules_list_url_from_pr
@@ -252,27 +238,6 @@ jobs:
             Write-Host "url NOT found"
             Add-Content -Path $env:GITHUB_OUTPUT -Value "url="
           }
-
-      - name: Look for xapi module in dependencies
-        id: run-ui-tests
-        shell: pwsh
-        run: |
-          $manifestFile = Get-ChildItem -Path ${{ github.workspace }} -Recurse -Filter "module.manifest" | Where-Object { $_.FullName -like "*/src/*/module.manifest" } | Select-Object -First 1
-          if (-not $manifestFile) {
-            Write-Error "No module.manifest file found in src subdirectories"
-            exit 1
-          }
-          Write-Host "Found module.manifest at: $($manifestFile.FullName)"
-          $manifestContent = Get-Content $manifestFile.FullName -Raw
-          $containsXapi = 'false'
-          $dependecies = $(Select-Xml -Content $manifestContent -XPath "//dependencies").Node.dependency
-          foreach ($dependency in $dependecies) {
-            if ($dependency.id -eq 'VirtoCommerce.Xapi') {
-              Write-Host "Found VirtoCommerce.Xapi in dependencies"
-              $containsXapi = 'true'
-            }
-          }
-          echo "result=$containsXapi" >> $env:GITHUB_OUTPUT
 
       - name: Setup Git Credentials
         if: ${{ (github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
@@ -320,51 +285,31 @@ jobs:
         run: |
           echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
 
-  ui-auto-tests:
+  auto-tests:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.27
+    needs: ci
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
     with:
       installModules: 'false'
       installCustomModule: 'true'
       customModuleId:  ${{ needs.ci.outputs.moduleId }}
       customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
       requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      runTests: ${{ needs.ci.outputs.run-ui-tests }}
       vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
+      testSuites: 'graphql,restapi'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
-
-  module-katalon-tests:
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-        (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.27
-    with:
-      katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
-      katalonRepoBranch: 'dev'
-      testSuite: 'Test Suites/Modules/Platform_collection'
-      installModules: 'false'
-      installCustomModule: 'true'
-      customModuleId:  ${{ needs.ci.outputs.moduleId }}
-      customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
-      requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      platformDockerTag: 'dev-linux-latest'
-      storefrontDockerTag: 'dev-linux-latest'
-    secrets:
-      envPAT: ${{ secrets.REPO_TOKEN }}
-      katalonApiKey: ${{ secrets.KATALON_API_KEY }}
 
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.30
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/.github/workflows/module-release-hotfix.yml
+++ b/.github/workflows/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.27    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -35,7 +35,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install VirtoCommerce.GlobalTool
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.27    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.27    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.27
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.27
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.27    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/module.keep
+++ b/module.keep
@@ -1,0 +1,1 @@
+VirtoCommerce.Pages.Core.dll


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4848
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1009.0-pr-131-bfd6.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily CI/CD workflow changes (toolchain upgrades and test job replacement) that could affect build/test execution and release automation, but no runtime application code is modified.
> 
> **Overview**
> Updates GitHub Actions workflows to `v3.800.30`, including bumping `actions/*` versions and moving CI from Node `20` to `24`.
> 
> Simplifies the pipeline by removing commit-message/XAPI gating logic and the Katalon e2e job, and replacing `ui-auto-tests` with a new `pytest-tests`-based `auto-tests` job that runs `graphql` and `restapi` suites.
> 
> Adds `module.keep` to ensure `VirtoCommerce.Pages.Core.dll` is included in the module output/package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfd6f6c011d9e1d27342bffaca255b675dad8388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->