### PR TITLE
VCST-5069: Normalize page status before savings

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Data/Services/GroupedPageService.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Data/Services/GroupedPageService.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.Extensions.Logging;
 using VirtoCommerce.PageBuilderModule.Core.Events;
 using VirtoCommerce.PageBuilderModule.Core.Models;
 using VirtoCommerce.PageBuilderModule.Core.Services;
@@ -8,6 +9,7 @@ using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Data.GenericCrud;
+using static VirtoCommerce.PageBuilderModule.Core.ModuleConstants.PageStatuses;
 
 namespace VirtoCommerce.PageBuilderModule.Data.Services
 {
@@ -15,7 +17,8 @@ namespace VirtoCommerce.PageBuilderModule.Data.Services
         Func<IPageBuilderModuleRepository> repositoryFactory,
         Func<IContentStreamRepository> contentStreamRepositoryFactory,
         IPlatformMemoryCache platformMemoryCache,
-        IEventPublisher eventPublisher)
+        IEventPublisher eventPublisher,
+        ILogger<GroupedPageService> logger)
         : CrudService<GroupedPageBuilderPage, GroupedPageBuilderPageEntity, GroupedPageBuilderPageChangingEvent,
                 GroupedPageBuilderPageChangedEvent>(repositoryFactory, platformMemoryCache, eventPublisher),
             IGroupedPageService
@@ -24,6 +27,46 @@ namespace VirtoCommerce.PageBuilderModule.Data.Services
         {
             var result = await ((IPageBuilderModuleRepository)repository).GetGroupedPageBuilderPagesByIdsAsync(ids, responseGroup);
             return result;
+        }
+
+        protected override Task BeforeSaveChanges(IList<GroupedPageBuilderPage> models)
+        {
+            foreach (var group in models)
+            {
+                NormalizePublishedPages(group);
+            }
+
+            return base.BeforeSaveChanges(models);
+        }
+
+        // Enforces invariant: at most one Published page per group.
+        // If multiple Published exist, keeps the newest by CreatedDate and demotes the rest to Archived.
+        // The change goes through the regular save flow, so the affected pages get re-indexed via the GroupedPageBuilderPageChangedEvent handler.
+        private void NormalizePublishedPages(GroupedPageBuilderPage group)
+        {
+            if (group?.Pages == null)
+            {
+                return;
+            }
+
+            var publishedPages = group.Pages.Where(x => x.Status == Published).ToList();
+            if (publishedPages.Count <= 1)
+            {
+                return;
+            }
+
+            var keep = publishedPages.OrderByDescending(x => x.CreatedDate).First();
+            foreach (var page in publishedPages)
+            {
+                if (page.Id == keep.Id)
+                {
+                    continue;
+                }
+
+                page.Status = Archived;
+                logger.LogWarning("Page '{PageId}' in group '{GroupId}' had Published status while another Published page exists. Demoted to Archived.",
+                    page.Id, group.Id);
+            }
         }
 
         public async Task<string> LoadContent(string pageId, CancellationToken cancellationToken = default)

--- a/src/VirtoCommerce.PageBuilderModule.Data/Services/GroupedPageService.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Data/Services/GroupedPageService.cs
@@ -29,20 +29,23 @@ namespace VirtoCommerce.PageBuilderModule.Data.Services
             return result;
         }
 
-        protected override Task BeforeSaveChanges(IList<GroupedPageBuilderPage> models)
+        protected override async Task BeforeSaveChanges(IList<GroupedPageBuilderPage> models)
         {
             foreach (var group in models)
             {
-                NormalizePublishedPages(group);
+                await NormalizePublishedPages(group);
             }
 
-            return base.BeforeSaveChanges(models);
+            await base.BeforeSaveChanges(models);
         }
 
         // Enforces invariant: at most one Published page per group.
-        // If multiple Published exist, keeps the newest by CreatedDate and demotes the rest to Archived.
-        // The change goes through the regular save flow, so the affected pages get re-indexed via the GroupedPageBuilderPageChangedEvent handler.
-        private void NormalizePublishedPages(GroupedPageBuilderPage group)
+        // If multiple Published exist, picks the page that is transitioning to Published in this save
+        // (compared against DB state) and demotes the rest to Archived. This handles the legitimate
+        // PublishGroup flow silently. If no clear transition exists (data anomaly from import/migration),
+        // falls back to "newest by CreatedDate" and logs a warning.
+        // Demoted pages get re-indexed via the GroupedPageBuilderPageChangedEvent handler.
+        private async Task NormalizePublishedPages(GroupedPageBuilderPage group)
         {
             if (group?.Pages == null)
             {
@@ -55,17 +58,43 @@ namespace VirtoCommerce.PageBuilderModule.Data.Services
                 return;
             }
 
-            var keep = publishedPages.OrderByDescending(x => x.CreatedDate).First();
-            foreach (var page in publishedPages)
-            {
-                if (page.Id == keep.Id)
-                {
-                    continue;
-                }
+            PageBuilderPage keep = null;
 
+            if (!string.IsNullOrEmpty(group.Id))
+            {
+                using var repository = repositoryFactory();
+                var existingEntities = await repository.GetGroupedPageBuilderPagesByIdsAsync([group.Id], null);
+                var existingPages = existingEntities.FirstOrDefault()?.Pages;
+                if (existingPages != null)
+                {
+                    var existingStatusById = existingPages
+                        .Where(p => !string.IsNullOrEmpty(p.Id))
+                        .ToDictionary(p => p.Id, p => p.Status);
+
+                    var newlyPromoted = publishedPages
+                        .Where(p => !string.IsNullOrEmpty(p.Id)
+                            && existingStatusById.TryGetValue(p.Id, out var oldStatus)
+                            && oldStatus != Published)
+                        .ToList();
+
+                    if (newlyPromoted.Count == 1)
+                    {
+                        keep = newlyPromoted[0];
+                    }
+                }
+            }
+
+            if (keep == null)
+            {
+                keep = publishedPages.OrderByDescending(x => x.CreatedDate).First();
+                logger.LogWarning("Group '{GroupId}' has multiple Published pages without a clear status transition. " +
+                    "Keeping page '{KeepId}' (newest CreatedDate) and demoting the rest to Archived.",
+                    group.Id, keep.Id);
+            }
+
+            foreach (var page in publishedPages.Where(p => p.Id != keep.Id))
+            {
                 page.Status = Archived;
-                logger.LogWarning("Page '{PageId}' in group '{GroupId}' had Published status while another Published page exists. Demoted to Archived.",
-                    page.Id, group.Id);
             }
         }
 

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/store/ui/effects.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/store/ui/effects.ts
@@ -129,12 +129,22 @@ export class TemplateEditorUiEffects {
 
     notifySuccessSave$ = createEffect(() => this.actions$.pipe(
         ofType(actions.saveTemplateSuccess),
-        switchMap(({ templateKey, parentKey, template }) => [
-            sharedActions.showNotification({ message: `Template ${template.settings['name']} saved successfully`, msgType: 'success', top: true }),
-            parent
-                ? sharedActions.setDirtyState({ parentKey, templateKey, dirty: false })
-                : sharedActions.setRootDirtyState({ templateKey, dirty: false })
-        ])
+        switchMap(({ templateKey, parentKey, template }) => {
+            const templateName = template.settings['name'] ? <string>template.settings['name'] : '';
+            if (!template.settings['name']) {
+                console.warn('Template name is empty. It may cause issues with notifications.', template);
+            }
+            return [
+                sharedActions.showNotification({
+                    message: `Template ${templateName} saved successfully`,
+                    msgType: 'success',
+                    top: true
+                }),
+                parent
+                    ? sharedActions.setDirtyState({ parentKey, templateKey, dirty: false })
+                    : sharedActions.setRootDirtyState({ templateKey, dirty: false })
+            ];
+        })
     ));
 
     notifyFailsSave$ = createEffect(() => this.actions$.pipe(

--- a/src/VirtoCommerce.PageBuilderModule.Web/Controllers/Api/PageBuilderPageController.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Controllers/Api/PageBuilderPageController.cs
@@ -10,11 +10,13 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using VirtoCommerce.ContentModule.Core.Model;
 using VirtoCommerce.PageBuilderModule.Core;
+using VirtoCommerce.PageBuilderModule.Core.Events;
 using VirtoCommerce.PageBuilderModule.Core.Models;
 using VirtoCommerce.PageBuilderModule.Core.Services;
 using VirtoCommerce.PageBuilderModule.Data.Authorization;
 using VirtoCommerce.Pages.Core.Search;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
 using static VirtoCommerce.PageBuilderModule.Core.ModuleConstants.PageStatuses;
 
 namespace VirtoCommerce.PageBuilderModule.Web.Controllers.Api;
@@ -27,6 +29,7 @@ public class PageBuilderPageController(
     IGroupedPageSearchService groupedPageSearchService,
     IAuthorizationService authorizationService,
     IPageDocumentSearchService pageDocumentSearchService,
+    IEventPublisher eventPublisher,
     ILogger<PageBuilderPageController> logger)
     : Controller
 {
@@ -112,7 +115,9 @@ public class PageBuilderPageController(
         await groupedPageService.SaveChangesAsync([groupedPage]);
         if (newGroup)
         {
-            await WriteDefaultContent(groupedPage.Pages[0].Id, cancellationToken);
+            var newPageId = groupedPage.Pages[0].Id;
+            await WriteDefaultContent(newPageId, cancellationToken);
+            await RaisePageContentChanged(newPageId, cancellationToken);
         }
 
         return Ok(groupedPage);
@@ -138,6 +143,7 @@ public class PageBuilderPageController(
 
         await groupedPageService.SaveChangesAsync([model]);
         await WriteDefaultContent(draftPage.Id, cancellationToken);
+        await RaisePageContentChanged(draftPage.Id, cancellationToken);
 
         return Ok(model);
     }
@@ -348,6 +354,7 @@ public class PageBuilderPageController(
 
         var pageId = draftPage!.Id;
         await groupedPageService.SaveStreamAsContentAsync(pageId, Request.Body, cancellationToken);
+        await RaisePageContentChanged(pageId, cancellationToken);
 
         return NoContent();
     }
@@ -399,6 +406,7 @@ public class PageBuilderPageController(
         }
 
         await groupedPageService.CopyPageContentAsync(sourcePageId, targetDraft.Id, cancellationToken);
+        await RaisePageContentChanged(targetDraft.Id, cancellationToken);
 
         return NoContent();
     }
@@ -418,5 +426,25 @@ public class PageBuilderPageController(
 
         await groupedPageService.SaveStreamAsContentAsync(pageId, stream, cancellationToken);
 
+    }
+
+    // Re-fires page-changed event after content has been written so the page gets re-indexed
+    // with its actual content (group-level save events fire before content is persisted).
+    private async Task RaisePageContentChanged(string pageId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(pageId))
+        {
+            return;
+        }
+
+        var pages = await crudService.GetAsync([pageId]);
+        var page = pages.FirstOrDefault();
+        if (page == null)
+        {
+            return;
+        }
+
+        var entry = new GenericChangedEntry<PageBuilderPage>(page, EntryState.Modified);
+        await eventPublisher.Publish(new PageBuilderPageChangedEvent([entry]), cancellationToken);
     }
 }

--- a/src/VirtoCommerce.PageBuilderModule.Web/Controllers/Api/PageBuilderPageController.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Controllers/Api/PageBuilderPageController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -86,16 +87,9 @@ public class PageBuilderPageController(
         // get the existing grouped page for pages Ids
         var groupedPage = await groupedPageService.GetByIdAsync(model.Id);
 
-        var newGroup = false;
-
         if (groupedPage == null)
         {
             groupedPage = AbstractTypeFactory<GroupedPageBuilderPage>.TryCreateInstance();
-            var draftPage = AbstractTypeFactory<PageBuilderPage>.TryCreateInstance();
-            draftPage.Status = Draft;
-            draftPage.StoreId = model.StoreId;
-            groupedPage.Pages.Add(draftPage);
-            newGroup = true;
         }
         else if (groupedPage.Status == Archived)
         {
@@ -112,13 +106,28 @@ public class PageBuilderPageController(
         groupedPage.EndDate = model.EndDate;
         groupedPage.OrganizationId = model.OrganizationId;
 
-        await groupedPageService.SaveChangesAsync([groupedPage]);
-        if (newGroup)
+        // Ensure a draft page exists so the metadata edit lives in a working copy and Published stays untouched.
+        // If only a Published page exists, spin up a new draft and remember to seed it with the published content.
+        var draftPage = groupedPage.Pages.FirstOrDefault(x => x.Status == Draft);
+        var sourcePageId = (string)null;
+        if (draftPage == null)
         {
-            var newPageId = groupedPage.Pages[0].Id;
-            await WriteDefaultContent(newPageId, cancellationToken);
-            await RaisePageContentChanged(newPageId, cancellationToken);
+            sourcePageId = groupedPage.Pages.FirstOrDefault(x => x.Status == Published)?.Id;
+            draftPage = AbstractTypeFactory<PageBuilderPage>.TryCreateInstance();
+            draftPage.Status = Draft;
+            draftPage.StoreId = groupedPage.StoreId;
+            groupedPage.Pages.Add(draftPage);
         }
+
+        await groupedPageService.SaveChangesAsync([groupedPage]);
+
+        if (sourcePageId != null)
+        {
+            await groupedPageService.CopyPageContentAsync(sourcePageId, draftPage.Id, cancellationToken);
+        }
+
+        await SyncGroupSettingsToContent(draftPage.Id, groupedPage, cancellationToken);
+        await RaisePageContentChanged(draftPage.Id, cancellationToken);
 
         return Ok(groupedPage);
     }
@@ -142,7 +151,7 @@ public class PageBuilderPageController(
         model.Pages.Add(draftPage);
 
         await groupedPageService.SaveChangesAsync([model]);
-        await WriteDefaultContent(draftPage.Id, cancellationToken);
+        await SyncGroupSettingsToContent(draftPage.Id, model, cancellationToken);
         await RaisePageContentChanged(draftPage.Id, cancellationToken);
 
         return Ok(model);
@@ -416,16 +425,34 @@ public class PageBuilderPageController(
         StatusCode = (int)HttpStatusCode.Forbidden,
     };
 
-    private async Task WriteDefaultContent(string pageId, CancellationToken cancellationToken)
+    // Syncs Name/Permalink/CultureName from the group into the draft page's content JSON `settings` object.
+    // If the page has no content yet, starts from DefaultPageContent. If the existing content is not a JSON
+    // object, leaves it untouched (legacy / non-standard payload — don't try to fix it here).
+    private async Task SyncGroupSettingsToContent(string pageId, GroupedPageBuilderPage group, CancellationToken cancellationToken)
     {
-        using var stream = new System.IO.MemoryStream();
-        var writer = new System.IO.StreamWriter(stream);
-        await writer.WriteAsync(ModuleConstants.DefaultPageContent.AsMemory(), cancellationToken);
-        await writer.FlushAsync(cancellationToken);
-        stream.Position = 0;
+        var content = await groupedPageService.LoadContent(pageId, cancellationToken);
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            content = ModuleConstants.DefaultPageContent;
+        }
 
-        await groupedPageService.SaveStreamAsContentAsync(pageId, stream, cancellationToken);
+        var node = JsonNode.Parse(content);
+        if (node is not JsonObject root)
+        {
+            return;
+        }
 
+        if (root["settings"] is not JsonObject settings)
+        {
+            settings = new JsonObject();
+            root["settings"] = settings;
+        }
+
+        settings["name"] = group.Name;
+        settings["permalink"] = group.Permalink;
+        settings["cultureName"] = group.CultureName;
+
+        await groupedPageService.SaveContent(pageId, root.ToJsonString(), cancellationToken);
     }
 
     // Re-fires page-changed event after content has been written so the page gets re-indexed


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5069
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1010.0-pr-133-3155.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches page publishing/state invariants and content persistence/indexing triggers, which could affect what page version is visible and searchable. Risk is mitigated by localized changes but impacts core page lifecycle flows.
> 
> **Overview**
> **Enforces a single `Published` page per group before persistence.** `GroupedPageService` now normalizes groups with multiple `Published` pages by keeping the newly-promoted page when detectable (otherwise keeping the newest by `CreatedDate`), demoting the rest to `Archived`, and logging a warning.
> 
> **Changes group update/create/content flows to operate on draft content and re-index correctly.** The API now ensures a `Draft` page exists when editing group metadata (optionally seeding it from the current `Published` content), writes group `Name`/`Permalink`/`CultureName` into the draft content JSON `settings`, and explicitly republishes a `PageBuilderPageChangedEvent` after any content write/copy so indexing sees the final content.
> 
> **Minor UI hardening.** Template save success notification now tolerates missing `template.settings['name']` and warns in console when empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3155dfdb53e75709a17d19edc99b5da636f79092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->