### PR TITLE
VCST-5163: Stable 15 — PageBuilderModule (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Core/VirtoCommerce.PageBuilderModule.Core.csproj
+++ b/src/VirtoCommerce.PageBuilderModule.Core/VirtoCommerce.PageBuilderModule.Core.csproj
@@ -4,12 +4,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Pages.Core" Version="3.1004.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
+    <PackageReference Include="VirtoCommerce.Pages.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.PageBuilderModule.Data.MySql/VirtoCommerce.PageBuilderModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.PageBuilderModule.Data.MySql/VirtoCommerce.PageBuilderModule.Data.MySql.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PageBuilderModule.Data\VirtoCommerce.PageBuilderModule.Data.csproj" />

--- a/src/VirtoCommerce.PageBuilderModule.Data.PostgreSql/VirtoCommerce.PageBuilderModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.PageBuilderModule.Data.PostgreSql/VirtoCommerce.PageBuilderModule.Data.PostgreSql.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PageBuilderModule.Data\VirtoCommerce.PageBuilderModule.Data.csproj" />

--- a/src/VirtoCommerce.PageBuilderModule.Data.SqlServer/VirtoCommerce.PageBuilderModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.PageBuilderModule.Data.SqlServer/VirtoCommerce.PageBuilderModule.Data.SqlServer.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PageBuilderModule.Data\VirtoCommerce.PageBuilderModule.Data.csproj" />

--- a/src/VirtoCommerce.PageBuilderModule.Data/ExportImport/PageBuilderExportImport.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Data/ExportImport/PageBuilderExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -20,7 +21,7 @@ public sealed class PageBuilderExportImport(
 {
     private const int BatchSize = 50;
 
-    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -75,7 +76,7 @@ public sealed class PageBuilderExportImport(
         await writer.FlushAsync();
     }
 
-    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -93,7 +94,7 @@ public sealed class PageBuilderExportImport(
         }
     }
 
-    private async Task ImportPagesArrayAsync(JsonTextReader reader, ExportImportProgressInfo progressInfo, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    private async Task ImportPagesArrayAsync(JsonTextReader reader, ExportImportProgressInfo progressInfo, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         if (!await reader.ReadAsync() || reader.TokenType != JsonToken.StartArray)
         {

--- a/src/VirtoCommerce.PageBuilderModule.Data/ExportImport/PageBuilderExportImport.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Data/ExportImport/PageBuilderExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.Collections.Generic;
 using System.IO;
@@ -31,13 +32,13 @@ public sealed class PageBuilderExportImport(
         using var sw = new StreamWriter(outStream, leaveOpen: true);
         using var writer = new JsonTextWriter(sw);
 
-        await writer.WriteStartObjectAsync();
+        await writer.WriteStartObjectAsync(cancellationToken);
 
         progressInfo.Description = "Page Builder pages are started to export";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("PageBuilderPages");
-        await writer.WriteStartArrayAsync();
+        await writer.WritePropertyNameAsync("PageBuilderPages", cancellationToken);
+        await writer.WriteStartArrayAsync(cancellationToken);
 
         var criteria = AbstractTypeFactory<PageBuilderPageSearchCriteria>.TryCreateInstance();
         criteria.Take = BatchSize;
@@ -58,7 +59,7 @@ public sealed class PageBuilderExportImport(
                 processedCount++;
             }
 
-            await writer.FlushAsync();
+            await writer.FlushAsync(cancellationToken);
 
             progressInfo.Description = $"{processedCount} of {searchResult.TotalCount} page builder pages have been exported";
             progressInfo.ProcessedCount = processedCount;
@@ -71,9 +72,9 @@ public sealed class PageBuilderExportImport(
             }
         }
 
-        await writer.WriteEndArrayAsync();
-        await writer.WriteEndObjectAsync();
-        await writer.FlushAsync();
+        await writer.WriteEndArrayAsync(cancellationToken);
+        await writer.WriteEndObjectAsync(cancellationToken);
+        await writer.FlushAsync(cancellationToken);
     }
 
     public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
@@ -85,7 +86,7 @@ public sealed class PageBuilderExportImport(
         using var streamReader = new StreamReader(inputStream, leaveOpen: true);
         using var reader = new JsonTextReader(streamReader);
 
-        while (await reader.ReadAsync())
+        while (await reader.ReadAsync(cancellationToken))
         {
             if (reader.TokenType == JsonToken.PropertyName && reader.Value?.ToString() == "PageBuilderPages")
             {
@@ -96,14 +97,14 @@ public sealed class PageBuilderExportImport(
 
     private async Task ImportPagesArrayAsync(JsonTextReader reader, ExportImportProgressInfo progressInfo, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
-        if (!await reader.ReadAsync() || reader.TokenType != JsonToken.StartArray)
+        if (!await reader.ReadAsync(cancellationToken) || reader.TokenType != JsonToken.StartArray)
         {
             return;
         }
 
         var processedCount = 0;
 
-        while (await reader.ReadAsync() && reader.TokenType != JsonToken.EndArray)
+        while (await reader.ReadAsync(cancellationToken) && reader.TokenType != JsonToken.EndArray)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.PageBuilderModule.Data/VirtoCommerce.PageBuilderModule.Data.csproj
+++ b/src/VirtoCommerce.PageBuilderModule.Data/VirtoCommerce.PageBuilderModule.Data.csproj
@@ -4,9 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.ContentModule.Data" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.ContentModule.Data" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PageBuilderModule.Core\VirtoCommerce.PageBuilderModule.Core.csproj" />

--- a/src/VirtoCommerce.PageBuilderModule.Web/Module.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -159,14 +160,14 @@ namespace VirtoCommerce.PageBuilderModule.Web
         }
 
         public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             return _appBuilder.ApplicationServices.GetRequiredService<PageBuilderExportImport>().DoExportAsync(outStream,
                 progressCallback, cancellationToken);
         }
 
         public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             return _appBuilder.ApplicationServices.GetRequiredService<PageBuilderExportImport>().DoImportAsync(inputStream,
                 progressCallback, cancellationToken);

--- a/src/VirtoCommerce.PageBuilderModule.Web/module.manifest
+++ b/src/VirtoCommerce.PageBuilderModule.Web/module.manifest
@@ -4,15 +4,15 @@
   <version>3.1012.0</version>
   <version-tag />
 
-  <platformVersion>3.1016.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Content" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Pages" version="3.1004.0" optional="true" />
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Content" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
+    <dependency id="VirtoCommerce.Pages" version="3.1007.0" optional="true" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <title>CMS Page Builder</title>

--- a/src/VirtoCommerce.PageBuilderModule.Web/package-lock.json
+++ b/src/VirtoCommerce.PageBuilderModule.Web/package-lock.json
@@ -451,9 +451,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -767,9 +767,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -1171,9 +1171,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -1354,9 +1354,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-            "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -1372,10 +1372,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "nanoid": "^3.3.12",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -1608,10 +1609,11 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }

--- a/tests/VirtoCommerce.PageBuilderModule.Tests/VirtoCommerce.PageBuilderModule.Tests.csproj
+++ b/tests/VirtoCommerce.PageBuilderModule.Tests/VirtoCommerce.PageBuilderModule.Tests.csproj
@@ -4,7 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 6). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–5 packages on nuget.org. Version handled by CI.

- Customer dep bumped to 3.1011.0.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency and platform API alignment can surface breaking changes from upstream packages; export/import signature changes must match platform 3.1039.0 at runtime.
> 
> **Overview**
> **Stable 15 alignment** for Page Builder: bumps **platform** to **3.1039.0** and refreshes VirtoCommerce module package references across Core, Data, and DB provider projects (Assets, Content, Customer, Pages, Store, Search, Platform.Data/Security).
> 
> **`module.manifest`** updates `platformVersion` and dependency versions to match (including Customer **3.1011.0** and Core **3.1007.0**).
> 
> **Platform export/import API change:** `PageBuilderExportImport` and `Module` `ExportAsync`/`ImportAsync` now take **`CancellationToken`** instead of **`ICancellationToken`**, with `using System.Threading` added where needed.
> 
> **Tests:** `coverlet.collector` **8.0.1 → 10.0.1**. **`package-lock.json`** picks up minor dev dependency bumps (e.g. postcss, nanoid).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d55f3cc58de6abaebc9e77588ac3d7e7cd5ebe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1012.0-pr-147-a054.zip