### PR TITLE
VCST-5274: sync baked page name with File name on rename

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/pages/edit-page.js
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/pages/edit-page.js
@@ -130,11 +130,25 @@ angular.module('virtoCommerce.pageBuilderModule')
                 if (!blade.isNew) {
                     originFileName = blade.origEntity.name;
                 }
-                if (!$scope.blade.currentEntity.settings.name) {
-                    $scope.blade.currentEntity.settings.name = blade.currentEntity.pageName;
+                var settings = $scope.blade.currentEntity.settings;
+                if (!settings.name) {
+                    settings.name = blade.currentEntity.pageName;
                 }
-                if (!$scope.blade.currentEntity.settings.permalink) {
-                    $scope.blade.currentEntity.settings.permalink = '/' + blade.currentEntity.pageName;
+                if (!settings.permalink) {
+                    settings.permalink = '/' + blade.currentEntity.pageName;
+                }
+                // VCST-5274: the baked settings.name/displayName are not updated when the File name
+                // is changed. When they still match the previous File name (i.e. they were auto-filled,
+                // not customized), keep them in sync with the new File name so the stored document —
+                // and everything derived from it (search index, SEO, storefront) — does not go stale.
+                var oldPageName = blade.origEntity && blade.origEntity.pageName;
+                if (oldPageName && oldPageName !== blade.currentEntity.pageName) {
+                    if (settings.name === oldPageName) {
+                        settings.name = blade.currentEntity.pageName;
+                    }
+                    if (settings.displayName === oldPageName) {
+                        settings.displayName = blade.currentEntity.pageName;
+                    }
                 }
                 reloadPageAndSave(newFileName, originFileName);
             };

--- a/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/pages/edit-page.js
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Scripts/blades/pages/edit-page.js
@@ -130,12 +130,12 @@ angular.module('virtoCommerce.pageBuilderModule')
                 if (!blade.isNew) {
                     originFileName = blade.origEntity.name;
                 }
-                var settings = $scope.blade.currentEntity.settings;
-                if (!settings.name) {
-                    settings.name = blade.currentEntity.pageName;
+                var pageSettings = $scope.blade.currentEntity.settings;
+                if (!pageSettings.name) {
+                    pageSettings.name = blade.currentEntity.pageName;
                 }
-                if (!settings.permalink) {
-                    settings.permalink = '/' + blade.currentEntity.pageName;
+                if (!pageSettings.permalink) {
+                    pageSettings.permalink = '/' + blade.currentEntity.pageName;
                 }
                 // VCST-5274: the baked settings.name/displayName are not updated when the File name
                 // is changed. When they still match the previous File name (i.e. they were auto-filled,
@@ -143,11 +143,11 @@ angular.module('virtoCommerce.pageBuilderModule')
                 // and everything derived from it (search index, SEO, storefront) — does not go stale.
                 var oldPageName = blade.origEntity && blade.origEntity.pageName;
                 if (oldPageName && oldPageName !== blade.currentEntity.pageName) {
-                    if (settings.name === oldPageName) {
-                        settings.name = blade.currentEntity.pageName;
+                    if (pageSettings.name === oldPageName) {
+                        pageSettings.name = blade.currentEntity.pageName;
                     }
-                    if (settings.displayName === oldPageName) {
-                        settings.displayName = blade.currentEntity.pageName;
+                    if (pageSettings.displayName === oldPageName) {
+                        pageSettings.displayName = blade.currentEntity.pageName;
                     }
                 }
                 reloadPageAndSave(newFileName, originFileName);


### PR DESCRIPTION
## Description

When a Page Builder page is renamed via the File name field, the name baked into the page document (settings.name / displayName) was left untouched, so the stored document — and the search index, SEO and storefront that derive from it — kept the old name.

On save, when settings.name / displayName still match the previous File name (i.e. they were auto-filled, not customized by the author), update them to the new File name. Custom display names are left intact.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5274
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1014.0-pr-149-3129.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow save-path change in the page editor with equality guards so only auto-filled names are updated; no auth or API contract changes.
> 
> **Overview**
> Fixes stale **settings.name** / **displayName** in the stored page JSON when an author renames the page via the **File name** field.
> 
> On save in `edit-page.js`, after the existing defaults for empty name/permalink, the flow now compares the new `pageName` to `blade.origEntity.pageName`. If the file name changed and **name** or **displayName** still equals the old file name (auto-filled, not customized), those fields are updated to the new file name before `reloadPageAndSave` runs. Custom titles that no longer match the old file name are left unchanged.
> 
> A small refactor introduces a local `pageSettings` reference for the save-path settings updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3129b3f0160558a2363ff348e91ffbae57f24496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->