### PR TITLE
fix(VCST-5429): make page content write atomic to prevent transient empty reads

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Data/Repositories/ContentStreamRepository.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Data/Repositories/ContentStreamRepository.cs
@@ -39,38 +39,76 @@ public abstract class ContentStreamRepository(PageBuilderModuleDbContext dbConte
         var connection = dbContext.Database.GetDbConnection();
         await dbContext.Database.OpenConnectionAsync(cancellationToken);
 
-        // write empty value first to avoid "out of memory" exception in case of large content
-        await using (var init = connection.CreateCommand())
+        var ambientTransaction = dbContext.Database.CurrentTransaction?.GetDbTransaction();
+        await WriteContentAsync(connection, ambientTransaction, pageId, reader, cancellationToken);
+    }
+
+    // The content is saved as an "empty first, then append chunks" sequence (writing empty first
+    // avoids an out-of-memory exception for large content). That sequence must be ATOMIC: without a
+    // transaction each statement auto-commits, so the empty intermediate value becomes globally
+    // visible and a concurrent reader (a different connection issuing GET .../content while a save
+    // is in flight) reads it as empty content — the transient empty-body read behind VCST-5429,
+    // which self-heals once the appends land. Wrapping the init + appends in one transaction means a
+    // concurrent reader only ever sees the previous committed content or the new one, never the empty
+    // intermediate. When the caller already runs inside a transaction, that ambient one is reused and
+    // left for the caller to commit.
+    protected virtual async Task WriteContentAsync(
+        DbConnection connection,
+        DbTransaction ambientTransaction,
+        string pageId,
+        TextReader reader,
+        CancellationToken cancellationToken)
+    {
+        var ownsTransaction = ambientTransaction == null;
+        var transaction = ambientTransaction ?? await connection.BeginTransactionAsync(cancellationToken);
+
+        try
         {
-            init.CommandText = InitContentSql;
-            SetIdParameter(init, pageId);
-            var tx = dbContext.Database.CurrentTransaction?.GetDbTransaction();
-            if (tx != null)
+            // write empty value first to avoid "out of memory" exception in case of large content
+            await using (var init = connection.CreateCommand())
             {
-                init.Transaction = tx;
+                init.CommandText = InitContentSql;
+                SetIdParameter(init, pageId);
+                init.Transaction = transaction;
+                await init.ExecuteNonQueryAsync(cancellationToken);
             }
 
-            await init.ExecuteNonQueryAsync(cancellationToken);
+            var buffer = new char[ContentBufferSize];
+            int read;
+            while ((read = await reader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+            {
+                await using var cmd = connection.CreateCommand();
+                cmd.CommandText = AppendContentChunkSql;
+                SetIdParameter(cmd, pageId);
+
+                var chunk = new string(buffer, 0, read);
+                SetContentChunk(cmd, chunk);
+
+                cmd.Transaction = transaction;
+
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            if (ownsTransaction)
+            {
+                await transaction.CommitAsync(cancellationToken);
+            }
         }
-
-        var buffer = new char[ContentBufferSize];
-        int read;
-        while ((read = await reader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        catch
         {
-            await using var cmd = connection.CreateCommand();
-            cmd.CommandText = AppendContentChunkSql;
-            SetIdParameter(cmd, pageId);
-
-            var chunk = new string(buffer, 0, read);
-            SetContentChunk(cmd, chunk);
-
-            var tx = dbContext.Database.CurrentTransaction?.GetDbTransaction();
-            if (tx != null)
+            if (ownsTransaction)
             {
-                cmd.Transaction = tx;
+                await transaction.RollbackAsync(cancellationToken);
             }
 
-            await cmd.ExecuteNonQueryAsync(cancellationToken);
+            throw;
+        }
+        finally
+        {
+            if (ownsTransaction)
+            {
+                await transaction.DisposeAsync();
+            }
         }
     }
 

--- a/tests/VirtoCommerce.PageBuilderModule.Tests/ContentStreamAtomicityTests.cs
+++ b/tests/VirtoCommerce.PageBuilderModule.Tests/ContentStreamAtomicityTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.PageBuilderModule.Data.PostgreSql;
+using VirtoCommerce.PageBuilderModule.Data.Repositories;
+using Xunit;
+
+namespace VirtoCommerce.PageBuilderModule.Tests
+{
+    // VCST-5429: SaveBinaryAsync persists content as "empty first, then append chunks" (writing empty
+    // first keeps memory bounded for large content). If that sequence is not atomic, each statement
+    // auto-commits and the empty intermediate becomes globally visible: a concurrent reader on another
+    // connection (a different GET .../content request, READ COMMITTED) reads empty content and returns
+    // a BOM-only empty body that self-heals on re-fetch — the reported transient empty render.
+    //
+    // The fake below models a real RDBMS truthfully: writes made inside a transaction stay invisible to
+    // other connections until commit; auto-committed statements are visible immediately. The atomicity
+    // fix (wrapping init + appends in one transaction) is what keeps every concurrent read non-empty.
+    public class ContentStreamAtomicityTests
+    {
+        [Fact]
+        public async Task SaveBinary_never_exposes_empty_content_to_a_concurrent_reader()
+        {
+            const string existingContent = "{\"blocks\":[\"a\",\"b\"]}";      // content already on the server
+            const string newContent = "{\"blocks\":[\"a\",\"b\",\"c\"]}";     // content being saved right now
+
+            var store = new FakeContentStore { Committed = existingContent };
+            var connection = new FakeDbConnection(store);
+
+            // What a concurrent reader (different connection, no transaction) would observe after each
+            // write statement the save executes.
+            var readerObservations = new List<string>();
+            connection.AfterWrite = () => readerObservations.Add(store.Committed);
+
+            var repository = new WriteProbe();
+            using var reader = new StringReader(newContent);
+
+            // No ambient transaction — mirrors the real DI path (a fresh scope/connection per content op).
+            await repository.Write(connection, ambient: null, pageId: "page-1", reader);
+
+            // The defect: a concurrent reader observes empty content mid-save.
+            // The fix: every observation stays the previous content until the atomic commit swaps in the new one.
+            Assert.All(readerObservations, observed => Assert.False(string.IsNullOrEmpty(observed)));
+            Assert.DoesNotContain(string.Empty, readerObservations);
+
+            // And the new content is still fully persisted.
+            Assert.Equal(newContent, store.Committed);
+        }
+
+        // Exposes the protected WriteContentAsync seam and forces small chunks so the init -> append
+        // window spans multiple statements. Reuses PostgreSQL's SQL; the parameter setters are redirected
+        // onto the fake command so no real ADO parameter collection is needed.
+        private sealed class WriteProbe() : PostgreSqlContentStreamRepository(null!)
+        {
+            protected override int ContentBufferSize => 4;
+
+            public Task Write(DbConnection connection, DbTransaction ambient, string pageId, TextReader reader) =>
+                WriteContentAsync(connection, ambient, pageId, reader, CancellationToken.None);
+
+            protected override void SetIdParameter(DbCommand cmd, string value) => ((FakeDbCommand)cmd).PageId = value;
+            protected override void SetContentChunk(DbCommand cmd, string chunk) => ((FakeDbCommand)cmd).Chunk = chunk;
+        }
+
+        // The committed (globally visible) content of the single page row.
+        private sealed class FakeContentStore
+        {
+            public string Committed { get; set; } = string.Empty;
+        }
+
+        private sealed class FakeDbConnection(FakeContentStore store) : DbConnection
+        {
+            public FakeContentStore Store => store;
+            public Action AfterWrite { get; set; }
+
+            public override string ConnectionString { get; set; } = string.Empty;
+            public override string Database => "fake";
+            public override string DataSource => "fake";
+            public override string ServerVersion => "1.0";
+            public override ConnectionState State => ConnectionState.Open;
+
+            public override void ChangeDatabase(string databaseName) { }
+            public override void Close() { }
+            public override void Open() { }
+
+            protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) =>
+                new FakeDbTransaction(this, store);
+
+            protected override DbCommand CreateDbCommand() => new FakeDbCommand(this) { Connection = this };
+        }
+
+        // Models transactional visibility: writes go to a private snapshot taken at BEGIN and only
+        // become visible (store.Committed) on Commit; Rollback discards them.
+        private sealed class FakeDbTransaction : DbTransaction
+        {
+            private readonly FakeDbConnection _connection;
+            private readonly FakeContentStore _store;
+
+            public FakeDbTransaction(FakeDbConnection connection, FakeContentStore store)
+            {
+                _connection = connection;
+                _store = store;
+                Pending = store.Committed;
+            }
+
+            public string Pending { get; set; }
+
+            protected override DbConnection DbConnection => _connection;
+            public override IsolationLevel IsolationLevel => IsolationLevel.ReadCommitted;
+
+            public override void Commit() => _store.Committed = Pending;
+            public override void Rollback() { /* discard Pending */ }
+        }
+
+        private sealed class FakeDbCommand(FakeDbConnection connection) : DbCommand
+        {
+            public string PageId { get; set; }
+            public string Chunk { get; set; }
+
+            public override string CommandText { get; set; } = string.Empty;
+            public override int CommandTimeout { get; set; }
+            public override CommandType CommandType { get; set; }
+            public override bool DesignTimeVisible { get; set; }
+            public override UpdateRowSource UpdatedRowSource { get; set; }
+            protected override DbConnection DbConnection { get; set; }
+            protected override DbParameterCollection DbParameterCollection => throw new NotSupportedException();
+            protected override DbTransaction DbTransaction { get; set; }
+
+            public override void Cancel() { }
+            public override void Prepare() { }
+
+            public override int ExecuteNonQuery()
+            {
+                var tx = DbTransaction as FakeDbTransaction;
+
+                if (IsInit)
+                {
+                    // UPDATE ... SET PageContent = '' — truncate to empty.
+                    if (tx != null)
+                    {
+                        tx.Pending = string.Empty;
+                    }
+                    else
+                    {
+                        connection.Store.Committed = string.Empty; // auto-commit: immediately visible
+                    }
+                }
+                else
+                {
+                    // UPDATE ... SET PageContent = PageContent || @chunk — append.
+                    if (tx != null)
+                    {
+                        tx.Pending += Chunk;
+                    }
+                    else
+                    {
+                        connection.Store.Committed += Chunk; // auto-commit: immediately visible
+                    }
+                }
+
+                connection.AfterWrite?.Invoke();
+                return 1;
+            }
+
+            // The init statement assigns a literal empty value; the append statement concatenates.
+            private bool IsInit =>
+                !CommandText.Contains("||") &&
+                !CommandText.Contains("CONCAT") &&
+                !CommandText.Contains(".WRITE");
+
+            public override object ExecuteScalar() => throw new NotSupportedException();
+            protected override DbParameter CreateDbParameter() => throw new NotSupportedException();
+            protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The Page Builder `GET /api/page-builder-pages/grouped/{groupId}/content` endpoint could transiently return HTTP 200 with an empty (BOM-only) body while a content save was in flight, self-healing on re-fetch — which the designer then rendered as an empty page. This makes the content write atomic so a concurrent read never observes the empty intermediate. Fixes JIRA **VCST-5429**.

## Root cause
`ContentStreamRepository.SaveBinaryAsync` (raw ADO.NET) persists content as "empty first, then append chunks": `InitContentSql` (`UPDATE PageBuilderPage SET PageContent = '' WHERE Id = @id`) followed by N chunked appends. There was no transaction around the sequence — and because the DI factory (`Module.cs`) hands each content operation a fresh scope/`DbContext`/connection, `CurrentTransaction` is always null — so every statement auto-committed. Between the init and the appends the empty `''` was committed and globally visible, so a concurrent `LoadBinaryAsync` on a different connection (a separate `GET .../content` request under READ COMMITTED) read empty content and returned a BOM-only body, self-healing once the appends landed.

## Fix
`src/VirtoCommerce.PageBuilderModule.Data/Repositories/ContentStreamRepository.cs` — extracted the write orchestration into a new `protected virtual WriteContentAsync(DbConnection, DbTransaction ambient, …)` seam and wrapped the init + appends in a single transaction (begin/commit, rollback on failure, dispose — only when it owns the transaction; when an ambient transaction is already present it is reused and left for the caller to commit, preserving prior behavior). Under READ COMMITTED a concurrent reader now only ever sees the previously committed content or the fully written new content — never the empty intermediate. No public contract, DTO, DB schema, migration, or SQL-dialect change; the per-provider SQL is untouched.

## Test (red → green)
- Added `ContentStreamAtomicityTests.SaveBinary_never_exposes_empty_content_to_a_concurrent_reader` in `tests/VirtoCommerce.PageBuilderModule.Tests` (new file, no existing test modified). It drives `WriteContentAsync` against a faithful fake `DbConnection`/`DbCommand`/`DbTransaction` that models real RDBMS READ-COMMITTED visibility (writes inside a transaction are invisible to other connections until commit; auto-committed statements are visible immediately), and asserts a concurrent reader never observes empty content mid-save and that the new content is fully persisted.
- Verified deterministically **red → green**: with the transaction wrapping reverted to autocommit the test fails with the first concurrent observation being `""` (the exact BOM-only empty-body symptom); with the fix it passes. Full suite: **8/8 pass**.

## Verification
- [x] dotnet build -c Debug — Build succeeded, 0 warnings (repo runs `TreatWarningsAsErrors=true`)
- [x] dotnet test (VirtoCommerce.PageBuilderModule.Tests) — 8/8 pass (7 pre-existing + 1 new)
- [ ] SonarCloud quality gate — evaluated by PR CI

## ⚠ Needs deploy verification
Statically verified only (unit-proven). The live symptom from VCST-5429 is an intermittent, non-deterministic race that could not be reproduced on demand, so it must be re-confirmed after this module builds and deploys to QA (regression pipeline + `/qa-verify-fix VCST-5429`).

## Scope note — one facet fixed; related follow-ups NOT in this PR
The empty render has more than one contributor in the same repo. This PR fixes the **backend content-write atomicity** facet (the strongest match for the raw "200 + BOM-only body during Save cycles" evidence). Deliberately out of scope here:
- **Frontend double-fetch + empty-binding** in the Page Builder designer (`usePageContentApi` / `usePageBuilderDetails`, PR #116): the designer fires two GETs to `/content` and can bind the view to the empty/aborted first response. That is a Vue/Angular concern outside this run's .NET scope — recommend a follow-up to dedupe the request and never bind an empty/aborted response.
- **`GetPageContent` page selection** can pick a just-created draft whose content row is not yet written (a separate non-atomic gap between the EF page-row save and the raw-ADO content write, spanning the controller/service boundary and two DI scopes). Fixing it well needs a cross-service transaction — larger and riskier than a minimal-diff fix, so intentionally left for a human decision.

## Reviewer notes
Minimal, single-repo diff; existing tests untouched (added only). The one new API surface is a `protected virtual` method on the public abstract `ContentStreamRepository` with a default implementation — providers need not override it (not a breaking change).

> 🤖 Opened by the QA auto-fix pipeline. **Human review + deploy verification required before merge — do not auto-merge.**

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5429
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1015.0-pr-153-f835.zip