### PR TITLE
VCST-5349: clear cache when page was updated

### DIFF
--- a/src/VirtoCommerce.PageBuilderModule.Data/Handlers/PageBuilderEventHandlerBase.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Data/Handlers/PageBuilderEventHandlerBase.cs
@@ -16,6 +16,14 @@ namespace VirtoCommerce.PageBuilderModule.Data.Handlers
         {
             var pageOperation = state.ToPageOperation(entry);
 
+            // A page with an unrecognized status maps to PageOperation.Unknown, which has no
+            // corresponding index status (GetPageDocumentStatus would throw). Such a page must not
+            // be pushed to the index, so skip it instead of raising an event for it.
+            if (pageOperation == PageOperation.Unknown)
+            {
+                return null;
+            }
+
             var group = await groupedPageService.GetByIdAsync(entry.GroupId);
             var content = await groupedPageService.LoadContent(entry.Id);
 
@@ -34,7 +42,7 @@ namespace VirtoCommerce.PageBuilderModule.Data.Handlers
 
         protected static async Task PublishPagesDomainEvents(IEnumerable<PagesDomainEvent> events, IEventPublisher eventPublisher)
         {
-            await Task.WhenAll(events.Select(e => eventPublisher.Publish(e)));
+            await Task.WhenAll(events.Where(e => e != null).Select(e => eventPublisher.Publish(e)));
         }
     }
 }

--- a/src/VirtoCommerce.PageBuilderModule.Data/Services/GroupedPageService.cs
+++ b/src/VirtoCommerce.PageBuilderModule.Data/Services/GroupedPageService.cs
@@ -5,6 +5,7 @@ using VirtoCommerce.PageBuilderModule.Core.Models;
 using VirtoCommerce.PageBuilderModule.Core.Services;
 using VirtoCommerce.PageBuilderModule.Data.Models;
 using VirtoCommerce.PageBuilderModule.Data.Repositories;
+using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
@@ -38,6 +39,38 @@ namespace VirtoCommerce.PageBuilderModule.Data.Services
             }
 
             await base.BeforeSaveChanges(models);
+        }
+
+        // A grouped save changes the status of child pages (publish/unpublish/archive), but the base
+        // ClearCache only expires GroupedPageBuilderPage regions. Read paths that hydrate individual
+        // pages — notably PageBuilderPageSearchService used by the search-index reindex provider —
+        // go through PageBuilderPage caches, which would otherwise keep serving the pre-change status
+        // until they expire. That makes a reindex write stale statuses to the index (the event-driven
+        // path is unaffected because it reads the freshly saved entry, not the cache). Invalidate the
+        // affected pages' caches here so a reindex immediately reflects the new status.
+        protected override void ClearCache(IList<GroupedPageBuilderPage> models)
+        {
+            base.ClearCache(models);
+
+            var pageIds = models
+                .Where(x => x?.Pages != null)
+                .SelectMany(x => x.Pages)
+                .Select(x => x.Id)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .Distinct()
+                .ToList();
+
+            if (pageIds.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var id in pageIds)
+            {
+                GenericCachingRegion<PageBuilderPage>.ExpireTokenForKey(id);
+            }
+
+            GenericSearchCachingRegion<PageBuilderPage>.ExpireRegion();
         }
 
         // Enforces invariant: at most one Published page per group.


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5349
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1020.0-pr-157-8fd8.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches caching and search-index event publishing after grouped saves; behavior change is targeted but affects reindex correctness and edge-case pages with unrecognized status.
> 
> **Overview**
> Fixes **stale page status in the search index** after grouped publish/unpublish/archive saves. `GroupedPageService` now overrides `ClearCache` to expire per-page `PageBuilderPage` cache keys and the page search cache region for all child pages in the saved groups—so reindex paths that read through `PageBuilderPageSearchService` see updated status instead of cached pre-save values.
> 
> **Search-index event handling** no longer builds or publishes `PagesDomainEvent` for pages whose status maps to `PageOperation.Unknown` (avoids `GetPageDocumentStatus` failures); `PublishPagesDomainEvents` ignores null events from that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd89052767cf22379f404591c1b809915d75f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->