### PR TITLE
feat(VCST-5704): page-wide anchor links in rich text fields

### DIFF
--- a/docs/controls/text.md
+++ b/docs/controls/text.md
@@ -22,6 +22,36 @@ This control provides a rich-text editor based on [ckeditor-angular](https://www
 ...
 ```
 
+## Page-wide anchor links
+
+The editor's **Link** dialog offers **Link to anchor in the text**. Out of the box CKEditor only
+lists anchors found in the field the dialog was opened from, which makes a table of contents or a
+"back to top" link impossible to build — the targets live in other sections.
+
+Page Builder replaces that list with every anchor on the page being edited:
+
+* the [`anchor` setting](../schemas.md#the-anchor-setting) of each section and block, falling back to
+  the generated item id;
+* in-text anchors added with the **Anchor** toolbar button (`<a name="...">`);
+* element ids authored through the **Source** view.
+
+Each entry is listed as `<item name> (<anchor>)` — the name comes from the schema's `displayField`,
+falling back to the schema `name`. Hidden sections and blocks are left out, because the storefront
+does not render them. The link is stored as a plain `#anchor` href, and reopening it resolves against
+the same list — so an anchor in another section is found instead of reported as missing. An anchor
+that is no longer on the page stays selected rather than silently clearing the link.
+
+Since every anchor is offered through the single **By Anchor Name** list, the **By Element Id** list
+is hidden and the picker uses the full width of the dialog.
+
+The **Anchor** panel of a section or block shows the value to link to, with a copy button.
+
+!!! note
+    The **Link to anchor in the text** option itself cannot be removed through configuration. It is
+    part of the link plugin's dialog definition, so neither `removePlugins: "anchor"` nor dropping
+    `Anchor` from the toolbar hides it — those only affect the toolbar button that creates in-text
+    anchors.
+
 
 <br>
 <br>

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -180,6 +180,28 @@ You can also organize reusable setting groups in separate files and include them
 |------------|-------------------------------|----------------------------|
 | `settings` | SectionPropertyDescriptor[] | Property descriptors array |
 
+#### The `anchor` setting
+
+`anchor` is a well-known setting id. When a theme declares it — usually in **_sections.json** and
+**_blocks.json**, so every section and block gets it — a content manager can give an item a readable
+link target instead of the generated id:
+
+```json
+{
+  "id": "anchor",
+  "label": "Anchor",
+  "type": "string",
+  "info": "Link to this section from a rich text field, for example #specifications."
+}
+```
+
+Page Builder normalizes the value into a slug (lowercased, spaces to dashes, other characters
+dropped) and offers it in the rich text [link dialog](controls/text.md#page-wide-anchor-links). When
+the setting is empty — or the value has nothing left after normalization — the generated item id is
+used instead.
+
+The theme is responsible for rendering the matching element id, applying the same normalization.
+
 ### Objects
 
 Section property can be object. In this case, it is necessary to describe the structure of this object in a separate file, that should be stored in folder `objects`.

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
@@ -1,5 +1,10 @@
 import { installPageWideAnchors } from './link-anchors';
-import { PageAnchor, PageAnchorsProvider, clearActivePageAnchorsProvider } from '@core/services';
+import {
+    PageAnchor,
+    PageAnchorsProvider,
+    clearActivePageAnchorsProvider,
+    setActivePageAnchorsProvider
+} from '@core/services';
 
 type CkAnchor = { name: string | null; id: string | null };
 type DialogListener = (event: any) => void;
@@ -46,6 +51,12 @@ function provider(anchors: PageAnchor[]): PageAnchorsProvider {
     return { getAnchors: () => anchors };
 }
 
+/** What activating the editor route does: publish its anchors, then let an editor install the patch. */
+function enterEditorRoute(pageProvider: PageAnchorsProvider): boolean {
+    setActivePageAnchorsProvider(pageProvider);
+    return installPageWideAnchors();
+}
+
 const pageAnchors: PageAnchor[] = [
     { value: 'imagexun', label: 'Hero image' },
     { value: 'specifications', label: 'Specifications' }
@@ -57,13 +68,13 @@ afterEach(() => {
 
 describe('installPageWideAnchors', () => {
     it('does nothing while the link plugin is not loaded', () => {
-        expect(installPageWideAnchors(provider(pageAnchors))).toBe(false);
+        expect(enterEditorRoute(provider(pageAnchors))).toBe(false);
     });
 
     it('publishes the page anchors to the link dialog', () => {
         const { link } = stubCkEditor();
 
-        expect(installPageWideAnchors(provider(pageAnchors))).toBe(true);
+        expect(enterEditorRoute(provider(pageAnchors))).toBe(true);
         expect(link.getEditorAnchors(null)).toEqual([
             { name: 'imagexun', id: null },
             { name: 'specifications', id: null }
@@ -72,7 +83,7 @@ describe('installPageWideAnchors', () => {
 
     it('never fills the element id slot, so the built href is always the picked anchor', () => {
         const { link } = stubCkEditor();
-        installPageWideAnchors(provider(pageAnchors));
+        enterEditorRoute(provider(pageAnchors));
 
         expect(link.getEditorAnchors(null).every((anchor: CkAnchor) => anchor.id === null)).toBe(true);
     });
@@ -81,27 +92,27 @@ describe('installPageWideAnchors', () => {
         const fieldLocal = [{ name: 'in-text', id: null }];
         const { link } = stubCkEditor(fieldLocal);
 
-        installPageWideAnchors(provider([]));
+        enterEditorRoute(provider([]));
 
         expect(link.getEditorAnchors(null)).toEqual(fieldLocal);
     });
 
     it('wraps the override only once, however many editor instances are created', () => {
         const { link } = stubCkEditor();
-        installPageWideAnchors(provider(pageAnchors));
+        enterEditorRoute(provider(pageAnchors));
         const wrapped = link.getEditorAnchors;
 
-        expect(installPageWideAnchors(provider(pageAnchors))).toBe(true);
+        expect(enterEditorRoute(provider(pageAnchors))).toBe(true);
         expect(link.getEditorAnchors).toBe(wrapped);
     });
 
     it('follows the provider of the editor route that is currently active', () => {
         const { link, listeners } = stubCkEditor();
-        installPageWideAnchors(provider(pageAnchors));
+        enterEditorRoute(provider(pageAnchors));
 
         // Leaving and re-entering the editor destroys the route scoped service and creates a new one,
         // while the override on the global CKEDITOR namespace survives.
-        installPageWideAnchors(provider([{ value: 'reopened', label: 'Reopened page' }]));
+        enterEditorRoute(provider([{ value: 'reopened', label: 'Reopened page' }]));
 
         expect(link.getEditorAnchors(null)).toEqual([{ name: 'reopened', id: null }]);
 
@@ -113,7 +124,7 @@ describe('installPageWideAnchors', () => {
     it('reflects later page edits because the provider is read on every open', () => {
         const { link } = stubCkEditor();
         let anchors = [...pageAnchors];
-        installPageWideAnchors({ getAnchors: () => anchors });
+        enterEditorRoute({ getAnchors: () => anchors });
 
         anchors = [{ value: 'added-later', label: 'Added later' }];
 
@@ -124,7 +135,7 @@ describe('installPageWideAnchors', () => {
 describe('anchor picker', () => {
     it('lists the item name with the anchor it links to', () => {
         const { listeners } = stubCkEditor();
-        installPageWideAnchors(provider(pageAnchors));
+        enterEditorRoute(provider(pageAnchors));
 
         const { anchorName } = openLinkDialog(listeners);
         anchorName.setup({});
@@ -138,7 +149,7 @@ describe('anchor picker', () => {
 
     it('shows the bare value when the item has no name of its own', () => {
         const { listeners } = stubCkEditor();
-        installPageWideAnchors(provider([{ value: 'text2', label: 'text2' }]));
+        enterEditorRoute(provider([{ value: 'text2', label: 'text2' }]));
 
         const { anchorName } = openLinkDialog(listeners);
         anchorName.setup({});
@@ -148,7 +159,7 @@ describe('anchor picker', () => {
 
     it('selects the anchor an existing link points at', () => {
         const { listeners } = stubCkEditor();
-        installPageWideAnchors(provider(pageAnchors));
+        enterEditorRoute(provider(pageAnchors));
 
         const { anchorName } = openLinkDialog(listeners);
         anchorName.setup({ anchor: { name: 'specifications' } });
@@ -158,7 +169,7 @@ describe('anchor picker', () => {
 
     it('keeps an anchor that is no longer on the page selectable, so the link survives a save', () => {
         const { listeners } = stubCkEditor();
-        installPageWideAnchors(provider(pageAnchors));
+        enterEditorRoute(provider(pageAnchors));
 
         const { anchorName } = openLinkDialog(listeners);
         anchorName.setup({ anchor: { name: 'typed-by-hand' } });
@@ -169,7 +180,7 @@ describe('anchor picker', () => {
 
     it('leaves the stock picker alone when the page has no anchors', () => {
         const { listeners } = stubCkEditor();
-        installPageWideAnchors(provider([]));
+        enterEditorRoute(provider([]));
 
         const { anchorName } = openLinkDialog(listeners);
         anchorName.setup({});
@@ -180,7 +191,7 @@ describe('anchor picker', () => {
 
     it('hides the empty element id cell so the anchor select gets the whole row', () => {
         const { listeners } = stubCkEditor();
-        installPageWideAnchors(provider(pageAnchors));
+        enterEditorRoute(provider(pageAnchors));
 
         const { anchorId } = openLinkDialog(listeners);
         anchorId.setup({});
@@ -191,7 +202,7 @@ describe('anchor picker', () => {
 
     it('keeps the element id cell when falling back to CKEditor anchors', () => {
         const { listeners } = stubCkEditor();
-        installPageWideAnchors(provider([]));
+        enterEditorRoute(provider([]));
 
         const { anchorId } = openLinkDialog(listeners);
         anchorId.cell.hide();
@@ -206,7 +217,7 @@ describe('clearActivePageAnchorsProvider', () => {
         const fieldLocal = [{ name: 'in-text', id: null }];
         const { link, listeners } = stubCkEditor(fieldLocal);
         const editorRoute = provider(pageAnchors);
-        installPageWideAnchors(editorRoute);
+        enterEditorRoute(editorRoute);
 
         // Leaving /pages tears the route scoped service down, while the override on the global
         // CKEDITOR namespace stays behind for the editors of every other module.
@@ -227,8 +238,8 @@ describe('clearActivePageAnchorsProvider', () => {
     it('ignores a provider that a later editor route has already replaced', () => {
         const { link } = stubCkEditor();
         const left = provider(pageAnchors);
-        installPageWideAnchors(left);
-        installPageWideAnchors(provider([{ value: 'reopened', label: 'Reopened page' }]));
+        enterEditorRoute(left);
+        enterEditorRoute(provider([{ value: 'reopened', label: 'Reopened page' }]));
 
         clearActivePageAnchorsProvider(left);
 

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
@@ -1,5 +1,5 @@
 import { installPageWideAnchors } from './link-anchors';
-import { PageAnchor, PageAnchorsProvider } from '@core/services';
+import { PageAnchor, PageAnchorsProvider, clearActivePageAnchorsProvider } from '@core/services';
 
 type CkAnchor = { name: string | null; id: string | null };
 type DialogListener = (event: any) => void;
@@ -198,5 +198,40 @@ describe('anchor picker', () => {
         anchorId.setup({});
 
         expect(anchorId.cell.hidden).toBe(false);
+    });
+});
+
+describe('clearActivePageAnchorsProvider', () => {
+    it('restores the field-local anchors once the editor route is destroyed', () => {
+        const fieldLocal = [{ name: 'in-text', id: null }];
+        const { link, listeners } = stubCkEditor(fieldLocal);
+        const editorRoute = provider(pageAnchors);
+        installPageWideAnchors(editorRoute);
+
+        // Leaving /pages tears the route scoped service down, while the override on the global
+        // CKEDITOR namespace stays behind for the editors of every other module.
+        clearActivePageAnchorsProvider(editorRoute);
+
+        expect(link.getEditorAnchors(null)).toEqual(fieldLocal);
+
+        const { anchorName, anchorId } = openLinkDialog(listeners);
+        anchorName.setup({});
+        anchorId.cell.hide();
+        anchorId.setup({});
+
+        expect(anchorName.setupCalls).toBe(1);
+        expect(anchorName.items).toEqual([]);
+        expect(anchorId.cell.hidden).toBe(false);
+    });
+
+    it('ignores a provider that a later editor route has already replaced', () => {
+        const { link } = stubCkEditor();
+        const left = provider(pageAnchors);
+        installPageWideAnchors(left);
+        installPageWideAnchors(provider([{ value: 'reopened', label: 'Reopened page' }]));
+
+        clearActivePageAnchorsProvider(left);
+
+        expect(link.getEditorAnchors(null)).toEqual([{ name: 'reopened', id: null }]);
     });
 });

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
@@ -86,17 +86,28 @@ describe('installPageWideAnchors', () => {
         expect(link.getEditorAnchors(null)).toEqual(fieldLocal);
     });
 
-    it('installs once, so a second editor instance does not wrap the override again', () => {
+    it('wraps the override only once, however many editor instances are created', () => {
         const { link } = stubCkEditor();
         installPageWideAnchors(provider(pageAnchors));
         const wrapped = link.getEditorAnchors;
 
-        expect(installPageWideAnchors(provider([{ value: 'other', label: 'Other' }]))).toBe(true);
+        expect(installPageWideAnchors(provider(pageAnchors))).toBe(true);
         expect(link.getEditorAnchors).toBe(wrapped);
-        expect(link.getEditorAnchors(null)).toEqual([
-            { name: 'imagexun', id: null },
-            { name: 'specifications', id: null }
-        ]);
+    });
+
+    it('follows the provider of the editor route that is currently active', () => {
+        const { link, listeners } = stubCkEditor();
+        installPageWideAnchors(provider(pageAnchors));
+
+        // Leaving and re-entering the editor destroys the route scoped service and creates a new one,
+        // while the override on the global CKEDITOR namespace survives.
+        installPageWideAnchors(provider([{ value: 'reopened', label: 'Reopened page' }]));
+
+        expect(link.getEditorAnchors(null)).toEqual([{ name: 'reopened', id: null }]);
+
+        const { anchorName } = openLinkDialog(listeners);
+        anchorName.setup({});
+        expect(anchorName.items).toEqual([['', undefined], ['Reopened page (reopened)', 'reopened']]);
     });
 
     it('reflects later page edits because the provider is read on every open', () => {

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
@@ -38,13 +38,23 @@ function stubCkEditor(fieldLocal: CkAnchor[] = []) {
 function openLinkDialog(listeners: DialogListener[]) {
     const anchorName = createSelect();
     const anchorId = createSelect();
-    const elements: Record<string, unknown> = { anchorName, anchorId };
+    // The containers the picker is assembled from, with the layout slots CKEditor ships them with.
+    const anchorOptions = { type: 'vbox', width: 260, align: 'center', padding: 0 };
+    const selectAnchorText = { type: 'fieldset', label: 'Select an Anchor' };
+    const selectAnchor = { type: 'hbox' };
+    const elements: Record<string, unknown> = {
+        anchorName,
+        anchorId,
+        anchorOptions,
+        selectAnchorText,
+        selectAnchor
+    };
 
     listeners.forEach(listener => listener({
         data: { name: 'link', definition: { getContents: () => ({ get: (id: string) => elements[id] }) } }
     }));
 
-    return { anchorName, anchorId };
+    return { anchorName, anchorId, anchorOptions, selectAnchorText, selectAnchor };
 }
 
 function provider(anchors: PageAnchor[]): PageAnchorsProvider {
@@ -209,6 +219,29 @@ describe('anchor picker', () => {
         anchorId.setup({});
 
         expect(anchorId.cell.hidden).toBe(false);
+    });
+});
+
+describe('anchor picker layout', () => {
+    it('spans the dialog instead of sitting centred in a 260px box', () => {
+        const { listeners } = stubCkEditor();
+        enterEditorRoute(provider(pageAnchors));
+
+        const { anchorOptions, selectAnchor } = openLinkDialog(listeners);
+
+        expect(anchorOptions.width).toBe('100%');
+        expect('align' in anchorOptions).toBe(false);
+        expect((<{ style?: string }>selectAnchor).style).toContain('width: 100%');
+    });
+
+    it('drops the fieldset frame and its legend, leaving the select its own label', () => {
+        const { listeners } = stubCkEditor();
+        enterEditorRoute(provider(pageAnchors));
+
+        const { selectAnchorText } = openLinkDialog(listeners);
+
+        expect(selectAnchorText.label).toBe('');
+        expect((<{ style?: string }>selectAnchorText).style).toContain('border: none');
     });
 });
 

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.spec.ts
@@ -1,0 +1,191 @@
+import { installPageWideAnchors } from './link-anchors';
+import { PageAnchor, PageAnchorsProvider } from '@core/services';
+
+type CkAnchor = { name: string | null; id: string | null };
+type DialogListener = (event: any) => void;
+
+const globalRef = globalThis as { CKEDITOR?: any };
+
+/** Mimics the parts of a CKEditor select and its table cell that the override touches. */
+function createSelect() {
+    const cell = { hidden: false, hide() { this.hidden = true; }, show() { this.hidden = false; } };
+    return {
+        items: <[string, string | undefined][]>[],
+        value: '',
+        setupCalls: 0,
+        cell,
+        clear() { this.items = []; },
+        add(label: string, value?: string) { this.items.push([label, value]); },
+        setValue(value: string) { this.value = value; },
+        getElement: () => ({ getParent: () => cell }),
+        setup(_data: unknown) { this.setupCalls++; }
+    };
+}
+
+function stubCkEditor(fieldLocal: CkAnchor[] = []) {
+    const link: { getEditorAnchors: (editor?: unknown) => CkAnchor[] } = { getEditorAnchors: () => fieldLocal };
+    const listeners: DialogListener[] = [];
+    globalRef.CKEDITOR = { plugins: { link }, on: (_: string, l: DialogListener) => listeners.push(l) };
+    return { link, listeners };
+}
+
+/** Runs the registered `dialogDefinition` handler against a stubbed link dialog. */
+function openLinkDialog(listeners: DialogListener[]) {
+    const anchorName = createSelect();
+    const anchorId = createSelect();
+    const elements: Record<string, unknown> = { anchorName, anchorId };
+
+    listeners.forEach(listener => listener({
+        data: { name: 'link', definition: { getContents: () => ({ get: (id: string) => elements[id] }) } }
+    }));
+
+    return { anchorName, anchorId };
+}
+
+function provider(anchors: PageAnchor[]): PageAnchorsProvider {
+    return { getAnchors: () => anchors };
+}
+
+const pageAnchors: PageAnchor[] = [
+    { value: 'imagexun', label: 'Hero image' },
+    { value: 'specifications', label: 'Specifications' }
+];
+
+afterEach(() => {
+    delete globalRef.CKEDITOR;
+});
+
+describe('installPageWideAnchors', () => {
+    it('does nothing while the link plugin is not loaded', () => {
+        expect(installPageWideAnchors(provider(pageAnchors))).toBe(false);
+    });
+
+    it('publishes the page anchors to the link dialog', () => {
+        const { link } = stubCkEditor();
+
+        expect(installPageWideAnchors(provider(pageAnchors))).toBe(true);
+        expect(link.getEditorAnchors(null)).toEqual([
+            { name: 'imagexun', id: null },
+            { name: 'specifications', id: null }
+        ]);
+    });
+
+    it('never fills the element id slot, so the built href is always the picked anchor', () => {
+        const { link } = stubCkEditor();
+        installPageWideAnchors(provider(pageAnchors));
+
+        expect(link.getEditorAnchors(null).every((anchor: CkAnchor) => anchor.id === null)).toBe(true);
+    });
+
+    it('keeps CKEditor field-local anchors when the page has none', () => {
+        const fieldLocal = [{ name: 'in-text', id: null }];
+        const { link } = stubCkEditor(fieldLocal);
+
+        installPageWideAnchors(provider([]));
+
+        expect(link.getEditorAnchors(null)).toEqual(fieldLocal);
+    });
+
+    it('installs once, so a second editor instance does not wrap the override again', () => {
+        const { link } = stubCkEditor();
+        installPageWideAnchors(provider(pageAnchors));
+        const wrapped = link.getEditorAnchors;
+
+        expect(installPageWideAnchors(provider([{ value: 'other', label: 'Other' }]))).toBe(true);
+        expect(link.getEditorAnchors).toBe(wrapped);
+        expect(link.getEditorAnchors(null)).toEqual([
+            { name: 'imagexun', id: null },
+            { name: 'specifications', id: null }
+        ]);
+    });
+
+    it('reflects later page edits because the provider is read on every open', () => {
+        const { link } = stubCkEditor();
+        let anchors = [...pageAnchors];
+        installPageWideAnchors({ getAnchors: () => anchors });
+
+        anchors = [{ value: 'added-later', label: 'Added later' }];
+
+        expect(link.getEditorAnchors(null)).toEqual([{ name: 'added-later', id: null }]);
+    });
+});
+
+describe('anchor picker', () => {
+    it('lists the item name with the anchor it links to', () => {
+        const { listeners } = stubCkEditor();
+        installPageWideAnchors(provider(pageAnchors));
+
+        const { anchorName } = openLinkDialog(listeners);
+        anchorName.setup({});
+
+        expect(anchorName.items).toEqual([
+            ['', undefined],
+            ['Hero image (imagexun)', 'imagexun'],
+            ['Specifications (specifications)', 'specifications']
+        ]);
+    });
+
+    it('shows the bare value when the item has no name of its own', () => {
+        const { listeners } = stubCkEditor();
+        installPageWideAnchors(provider([{ value: 'text2', label: 'text2' }]));
+
+        const { anchorName } = openLinkDialog(listeners);
+        anchorName.setup({});
+
+        expect(anchorName.items).toEqual([['', undefined], ['text2', 'text2']]);
+    });
+
+    it('selects the anchor an existing link points at', () => {
+        const { listeners } = stubCkEditor();
+        installPageWideAnchors(provider(pageAnchors));
+
+        const { anchorName } = openLinkDialog(listeners);
+        anchorName.setup({ anchor: { name: 'specifications' } });
+
+        expect(anchorName.value).toBe('specifications');
+    });
+
+    it('keeps an anchor that is no longer on the page selectable, so the link survives a save', () => {
+        const { listeners } = stubCkEditor();
+        installPageWideAnchors(provider(pageAnchors));
+
+        const { anchorName } = openLinkDialog(listeners);
+        anchorName.setup({ anchor: { name: 'typed-by-hand' } });
+
+        expect(anchorName.items).toContainEqual(['typed-by-hand', 'typed-by-hand']);
+        expect(anchorName.value).toBe('typed-by-hand');
+    });
+
+    it('leaves the stock picker alone when the page has no anchors', () => {
+        const { listeners } = stubCkEditor();
+        installPageWideAnchors(provider([]));
+
+        const { anchorName } = openLinkDialog(listeners);
+        anchorName.setup({});
+
+        expect(anchorName.setupCalls).toBe(1);
+        expect(anchorName.items).toEqual([]);
+    });
+
+    it('hides the empty element id cell so the anchor select gets the whole row', () => {
+        const { listeners } = stubCkEditor();
+        installPageWideAnchors(provider(pageAnchors));
+
+        const { anchorId } = openLinkDialog(listeners);
+        anchorId.setup({});
+
+        expect(anchorId.cell.hidden).toBe(true);
+        expect(anchorId.setupCalls).toBe(1);
+    });
+
+    it('keeps the element id cell when falling back to CKEditor anchors', () => {
+        const { listeners } = stubCkEditor();
+        installPageWideAnchors(provider([]));
+
+        const { anchorId } = openLinkDialog(listeners);
+        anchorId.cell.hide();
+        anchorId.setup({});
+
+        expect(anchorId.cell.hidden).toBe(false);
+    });
+});

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
@@ -1,4 +1,4 @@
-import { PageAnchor, PageAnchorsProvider } from '@core/services';
+import { PageAnchor, PageAnchorsProvider, getActivePageAnchors, setActivePageAnchorsProvider } from '@core/services';
 
 /**
  * Anchor entry CKEditor's link dialog consumes. Stock CKEditor describes one anchor element through
@@ -81,10 +81,10 @@ export function installPageWideAnchors(provider: PageAnchorsProvider): boolean {
     }
 
     // The patches below live on the global CKEDITOR namespace and outlive the editor route, while the
-    // provider is route scoped and replaced on every visit. They read the current one through this
-    // reference so a page opened after leaving and re-entering the editor never lists the anchors of
-    // a destroyed service.
-    currentProvider = provider;
+    // provider is route scoped and replaced on every visit. They read the current one through the
+    // registry so a page opened after leaving and re-entering the editor never lists the anchors of a
+    // destroyed service.
+    setActivePageAnchorsProvider(provider);
 
     if (link.pbPageWideAnchorsInstalled) {
         return true;
@@ -93,7 +93,7 @@ export function installPageWideAnchors(provider: PageAnchorsProvider): boolean {
     const fieldLocalAnchors = link.getEditorAnchors.bind(link);
 
     link.getEditorAnchors = (editor: unknown) => {
-        const anchors = getAnchors();
+        const anchors = getActivePageAnchors();
         // Fall back to CKEditor's own lookup so an editor opened outside the page editor — or before
         // the page model is available — behaves exactly as it did before.
         return anchors.length
@@ -105,13 +105,6 @@ export function installPageWideAnchors(provider: PageAnchorsProvider): boolean {
     link.pbPageWideAnchorsInstalled = true;
 
     return true;
-}
-
-/** The provider of the editor route that is currently active. See `installPageWideAnchors`. */
-let currentProvider: PageAnchorsProvider | null = null;
-
-function getAnchors(): PageAnchor[] {
-    return currentProvider?.getAnchors() || [];
 }
 
 function customizeAnchorPicker(ckeditor: CkEditorNamespace): void {
@@ -130,7 +123,7 @@ function customizeAnchorPicker(ckeditor: CkEditorNamespace): void {
 
         const stockNameSetup = anchorName.setup;
         anchorName.setup = function (data: CkLinkData) {
-            const anchors = getAnchors();
+            const anchors = getActivePageAnchors();
             if (!anchors.length) {
                 stockNameSetup?.call(this, data);
                 return;
@@ -158,7 +151,7 @@ function customizeAnchorPicker(ckeditor: CkEditorNamespace): void {
             // Page anchors are all published through the name select, leaving this one empty. Hiding
             // its table cell — not just the select — lets the remaining one use the whole row.
             const cell = this.getElement().getParent();
-            if (getAnchors().length) {
+            if (getActivePageAnchors().length) {
                 cell?.hide();
             } else {
                 cell?.show();

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
@@ -36,12 +36,21 @@ type CkSetup = (this: CkSelect, data: CkLinkData) => void;
 
 interface CkElementDefinition {
     setup?: CkSetup;
+    /** Layout slots of the container definitions the anchor picker is assembled from. */
+    label?: string;
+    style?: string;
+    width?: string | number;
+    align?: string;
+}
+
+interface CkDialogContents {
+    get(id: string): CkElementDefinition | null;
 }
 
 interface CkDialogDefinitionEvent {
     data: {
         name: string;
-        definition: { getContents(id: string): { get(id: string): CkElementDefinition | null } | null };
+        definition: { getContents(id: string): CkDialogContents | null };
     };
 }
 
@@ -115,9 +124,11 @@ function customizeAnchorPicker(ckeditor: CkEditorNamespace): void {
         const anchorName = info?.get('anchorName');
         const anchorId = info?.get('anchorId');
 
-        if (!anchorName || !anchorId) {
+        if (!info || !anchorName || !anchorId) {
             return;
         }
+
+        flattenAnchorPicker(info);
 
         const stockNameSetup = anchorName.setup;
         anchorName.setup = function (data: CkLinkData) {
@@ -156,6 +167,41 @@ function customizeAnchorPicker(ckeditor: CkEditorNamespace): void {
             }
         };
     });
+}
+
+/**
+ * Puts the anchor picker on the same grid as every other link type.
+ *
+ * Stock CKEditor sizes it as a 260px fieldset centred in the dialog, because it holds two selects
+ * side by side — "By Anchor Name" and "By Element Id" — under a "Select an Anchor" legend. Page
+ * anchors are published through the name select alone, so the second one is hidden and both the
+ * frame and the centring only make the row look unlike the URL, e-mail and phone fields, which all
+ * span the dialog.
+ *
+ * The dialog definition is patched rather than the setup functions, because width and alignment are
+ * baked into the container markup when the dialog is built.
+ */
+function flattenAnchorPicker(info: CkDialogContents): void {
+    const options = info.get('anchorOptions');
+    if (options) {
+        options.width = '100%';
+        delete options.align;
+    }
+
+    const frame = info.get('selectAnchorText');
+    if (frame) {
+        // An empty label drops the legend; the fieldset element itself stays, so its default frame
+        // has to go through the inline style CKEditor copies onto it.
+        frame.label = '';
+        frame.style = 'border: none; padding: 0; margin: 0;';
+    }
+
+    // The selects size themselves to their table cell, and the cell to the row, so the row is where
+    // the full width has to be claimed.
+    const row = info.get('selectAnchor');
+    if (row) {
+        row.style = 'width: 100%;';
+    }
 }
 
 /** `Hero image (imagexun)`, or just the value when the item has no name of its own. */

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
@@ -1,4 +1,4 @@
-import { PageAnchor, PageAnchorsProvider, getActivePageAnchors, setActivePageAnchorsProvider } from '@core/services';
+import { PageAnchor, getActivePageAnchors } from '@core/services';
 
 /**
  * Anchor entry CKEditor's link dialog consumes. Stock CKEditor describes one anchor element through
@@ -70,21 +70,19 @@ interface CkEditorNamespace {
  *   existing `#value` href back to a list entry;
  * * the anchor picker itself, so it lists readable names instead of bare generated ids.
  *
+ * The patches are global and idempotent: they read whichever editor route is currently active
+ * through `getActivePageAnchors`, so every later editor instance — in this module or another one —
+ * reuses them and gets the anchors that belong to it.
+ *
  * @returns `true` once the override is in place, `false` while the link plugin is not loaded yet.
  */
-export function installPageWideAnchors(provider: PageAnchorsProvider): boolean {
+export function installPageWideAnchors(): boolean {
     const ckeditor = (globalThis as { CKEDITOR?: CkEditorNamespace }).CKEDITOR;
     const link = ckeditor?.plugins?.link;
 
     if (!ckeditor || !link?.getEditorAnchors) {
         return false;
     }
-
-    // The patches below live on the global CKEDITOR namespace and outlive the editor route, while the
-    // provider is route scoped and replaced on every visit. They read the current one through the
-    // registry so a page opened after leaving and re-entering the editor never lists the anchors of a
-    // destroyed service.
-    setActivePageAnchorsProvider(provider);
 
     if (link.pbPageWideAnchorsInstalled) {
         return true;

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
@@ -1,0 +1,161 @@
+import { PageAnchor, PageAnchorsProvider } from '@core/services';
+
+/**
+ * Anchor entry CKEditor's link dialog consumes. Stock CKEditor describes one anchor element through
+ * both slots — `name` from `<a name="...">` and `id` from the same element's id attribute — and
+ * offers each through its own select, "By Anchor Name" and "By Element Id". The href is then built
+ * as `'#' + (name || id)`.
+ *
+ * Page anchors are published through `name` only. Both selects commit unconditionally and `name`
+ * wins when the href is assembled, so the slot that is checked first is the one that always carries
+ * the picked value through, and the second select is left empty for the dialog patch to hide.
+ */
+interface CkAnchor {
+    name: string;
+    id: null;
+}
+
+interface CkDomElement {
+    hide(): void;
+    show(): void;
+    getParent(): CkDomElement | null;
+}
+
+interface CkSelect {
+    clear(): void;
+    add(label: string, value?: string): void;
+    setValue(value: string): void;
+    getElement(): CkDomElement;
+}
+
+interface CkLinkData {
+    anchor?: { name?: string; id?: string };
+}
+
+type CkSetup = (this: CkSelect, data: CkLinkData) => void;
+
+interface CkElementDefinition {
+    setup?: CkSetup;
+}
+
+interface CkDialogDefinitionEvent {
+    data: {
+        name: string;
+        definition: { getContents(id: string): { get(id: string): CkElementDefinition | null } | null };
+    };
+}
+
+interface CkLinkPlugin {
+    getEditorAnchors?: (editor: unknown) => CkAnchor[];
+    pbPageWideAnchorsInstalled?: boolean;
+}
+
+interface CkEditorNamespace {
+    on(event: 'dialogDefinition', listener: (event: CkDialogDefinitionEvent) => void): void;
+    plugins?: { link?: CkLinkPlugin };
+}
+
+/**
+ * Lifts the CKEditor link dialog out of its single-field scope.
+ *
+ * `CKEDITOR.plugins.link.getEditorAnchors` only scans the editable the dialog was opened from, so a
+ * content manager could not link to a heading rendered by another section — which is exactly what a
+ * table of contents or a jump link needs (VCST-5704). The option itself cannot be configured away:
+ * "Link to anchor in the text" is hardcoded in the link plugin's dialog definition and is not
+ * affected by `removePlugins: 'anchor'`, which only drops the toolbar button.
+ *
+ * Two things are patched:
+ *
+ * * `getEditorAnchors`, which decides whether the anchor picker is shown at all and resolves an
+ *   existing `#value` href back to a list entry;
+ * * the anchor picker itself, so it lists readable names instead of bare generated ids.
+ *
+ * @returns `true` once the override is in place, `false` while the link plugin is not loaded yet.
+ */
+export function installPageWideAnchors(provider: PageAnchorsProvider): boolean {
+    const ckeditor = (globalThis as { CKEDITOR?: CkEditorNamespace }).CKEDITOR;
+    const link = ckeditor?.plugins?.link;
+
+    if (!ckeditor || !link?.getEditorAnchors) {
+        return false;
+    }
+    if (link.pbPageWideAnchorsInstalled) {
+        return true;
+    }
+
+    const fieldLocalAnchors = link.getEditorAnchors.bind(link);
+
+    link.getEditorAnchors = (editor: unknown) => {
+        const anchors = provider.getAnchors();
+        // Fall back to CKEditor's own lookup so an editor opened outside the page editor — or before
+        // the page model is available — behaves exactly as it did before.
+        return anchors.length
+            ? anchors.map(anchor => (<CkAnchor>{ name: anchor.value, id: null }))
+            : fieldLocalAnchors(editor);
+    };
+
+    customizeAnchorPicker(ckeditor, provider);
+    link.pbPageWideAnchorsInstalled = true;
+
+    return true;
+}
+
+function customizeAnchorPicker(ckeditor: CkEditorNamespace, provider: PageAnchorsProvider): void {
+    ckeditor.on('dialogDefinition', event => {
+        if (event.data.name !== 'link') {
+            return;
+        }
+
+        const info = event.data.definition.getContents('info');
+        const anchorName = info?.get('anchorName');
+        const anchorId = info?.get('anchorId');
+
+        if (!anchorName || !anchorId) {
+            return;
+        }
+
+        const stockNameSetup = anchorName.setup;
+        anchorName.setup = function (data: CkLinkData) {
+            const anchors = provider.getAnchors();
+            if (!anchors.length) {
+                stockNameSetup?.call(this, data);
+                return;
+            }
+
+            const selected = data?.anchor?.name || '';
+
+            this.clear();
+            this.add('');
+            anchors.forEach(anchor => this.add(describeAnchor(anchor), anchor.value));
+
+            // An anchor typed by hand, or one that has since been removed from the page, would other-
+            // wise silently reset to the empty option and lose the link on save.
+            if (selected && !anchors.some(anchor => anchor.value === selected)) {
+                this.add(selected, selected);
+            }
+
+            this.setValue(selected);
+        };
+
+        const stockIdSetup = anchorId.setup;
+        anchorId.setup = function (data: CkLinkData) {
+            stockIdSetup?.call(this, data);
+
+            // Page anchors are all published through the name select, leaving this one empty. Hiding
+            // its table cell — not just the select — lets the remaining one use the whole row.
+            const cell = this.getElement().getParent();
+            if (provider.getAnchors().length) {
+                cell?.hide();
+            } else {
+                cell?.show();
+            }
+        };
+    });
+}
+
+/** `Hero image (imagexun)`, or just the value when the item has no name of its own. */
+function describeAnchor(anchor: PageAnchor): string {
+    return anchor.label && anchor.label !== anchor.value
+        ? `${anchor.label} (${anchor.value})`
+        : anchor.value;
+}

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/link-anchors.ts
@@ -79,6 +79,13 @@ export function installPageWideAnchors(provider: PageAnchorsProvider): boolean {
     if (!ckeditor || !link?.getEditorAnchors) {
         return false;
     }
+
+    // The patches below live on the global CKEDITOR namespace and outlive the editor route, while the
+    // provider is route scoped and replaced on every visit. They read the current one through this
+    // reference so a page opened after leaving and re-entering the editor never lists the anchors of
+    // a destroyed service.
+    currentProvider = provider;
+
     if (link.pbPageWideAnchorsInstalled) {
         return true;
     }
@@ -86,7 +93,7 @@ export function installPageWideAnchors(provider: PageAnchorsProvider): boolean {
     const fieldLocalAnchors = link.getEditorAnchors.bind(link);
 
     link.getEditorAnchors = (editor: unknown) => {
-        const anchors = provider.getAnchors();
+        const anchors = getAnchors();
         // Fall back to CKEditor's own lookup so an editor opened outside the page editor — or before
         // the page model is available — behaves exactly as it did before.
         return anchors.length
@@ -94,13 +101,20 @@ export function installPageWideAnchors(provider: PageAnchorsProvider): boolean {
             : fieldLocalAnchors(editor);
     };
 
-    customizeAnchorPicker(ckeditor, provider);
+    customizeAnchorPicker(ckeditor);
     link.pbPageWideAnchorsInstalled = true;
 
     return true;
 }
 
-function customizeAnchorPicker(ckeditor: CkEditorNamespace, provider: PageAnchorsProvider): void {
+/** The provider of the editor route that is currently active. See `installPageWideAnchors`. */
+let currentProvider: PageAnchorsProvider | null = null;
+
+function getAnchors(): PageAnchor[] {
+    return currentProvider?.getAnchors() || [];
+}
+
+function customizeAnchorPicker(ckeditor: CkEditorNamespace): void {
     ckeditor.on('dialogDefinition', event => {
         if (event.data.name !== 'link') {
             return;
@@ -116,7 +130,7 @@ function customizeAnchorPicker(ckeditor: CkEditorNamespace, provider: PageAnchor
 
         const stockNameSetup = anchorName.setup;
         anchorName.setup = function (data: CkLinkData) {
-            const anchors = provider.getAnchors();
+            const anchors = getAnchors();
             if (!anchors.length) {
                 stockNameSetup?.call(this, data);
                 return;
@@ -144,7 +158,7 @@ function customizeAnchorPicker(ckeditor: CkEditorNamespace, provider: PageAnchor
             // Page anchors are all published through the name select, leaving this one empty. Hiding
             // its table cell — not just the select — lets the remaining one use the whole row.
             const cell = this.getElement().getParent();
-            if (provider.getAnchors().length) {
+            if (getAnchors().length) {
                 cell?.hide();
             } else {
                 cell?.show();

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/text.component.html
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/text.component.html
@@ -5,4 +5,5 @@
   [data]="controlValue()"
   [type]="editorType"
   [config]="config"
+  (ready)="onEditorReady()"
   (dataChange)="onValueChanged($event)" />

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/text.component.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/text.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CKEditor4, CKEditorModule } from 'ckeditor4-angular';
 import { BaseControlDirective } from '@core/controls/base-control.directive';
-import { PAGE_ANCHORS_PROVIDER } from '@core/services';
 import { TextDescriptor } from '@models/controls';
 import { installPageWideAnchors } from './link-anchors';
 
@@ -13,10 +12,6 @@ import { installPageWideAnchors } from './link-anchors';
   imports: [CKEditorModule]
 })
 export class TextComponent extends BaseControlDirective<TextDescriptor> {
-
-  // Absent when a rich text control is used outside the page editor — anchor linking then keeps
-  // CKEditor's field-local behaviour.
-  private readonly pageAnchors = inject(PAGE_ANCHORS_PROVIDER, { optional: true });
 
   // CKEditor4 uses ambient const enums which are incompatible with isolatedModules.
   // Double cast is required because the enum type is nominal — string literals aren't
@@ -54,12 +49,11 @@ export class TextComponent extends BaseControlDirective<TextDescriptor> {
 
   /**
    * The link plugin only exists once an editor instance is ready, so the page-wide anchor override
-   * is installed here. It is global and idempotent — every later instance reuses it.
+   * is installed here. It is global and idempotent — every later instance reuses it — and falls back
+   * to CKEditor's field-local anchors wherever the page editor is not the active route.
    */
   onEditorReady(): void {
-    if (this.pageAnchors) {
-      installPageWideAnchors(this.pageAnchors);
-    }
+    installPageWideAnchors();
   }
 
   override onValueChanged = (newValue: any) => {

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/text.component.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/controls/text/text.component.ts
@@ -1,7 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { CKEditor4, CKEditorModule } from 'ckeditor4-angular';
 import { BaseControlDirective } from '@core/controls/base-control.directive';
+import { PAGE_ANCHORS_PROVIDER } from '@core/services';
 import { TextDescriptor } from '@models/controls';
+import { installPageWideAnchors } from './link-anchors';
 
 @Component({
   selector: 'app-text',
@@ -11,6 +13,10 @@ import { TextDescriptor } from '@models/controls';
   imports: [CKEditorModule]
 })
 export class TextComponent extends BaseControlDirective<TextDescriptor> {
+
+  // Absent when a rich text control is used outside the page editor — anchor linking then keeps
+  // CKEditor's field-local behaviour.
+  private readonly pageAnchors = inject(PAGE_ANCHORS_PROVIDER, { optional: true });
 
   // CKEditor4 uses ambient const enums which are incompatible with isolatedModules.
   // Double cast is required because the enum type is nominal — string literals aren't
@@ -45,6 +51,16 @@ export class TextComponent extends BaseControlDirective<TextDescriptor> {
   };
 
   config = this.defaultConfig;
+
+  /**
+   * The link plugin only exists once an editor instance is ready, so the page-wide anchor override
+   * is installed here. It is global and idempotent — every later instance reuses it.
+   */
+  onEditorReady(): void {
+    if (this.pageAnchors) {
+      installPageWideAnchors(this.pageAnchors);
+    }
+  }
 
   override onValueChanged = (newValue: any) => {
     if (this.controlValue() !== newValue) {

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/services/index.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/services/index.ts
@@ -7,3 +7,4 @@ export * from './assets.service';
 export * from './asset-library-api.service';
 export * from './asset-library.service';
 export * from './asset-url.service';
+export * from './page-anchors.provider';

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/services/page-anchors.provider.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/services/page-anchors.provider.ts
@@ -1,0 +1,24 @@
+import { InjectionToken } from '@angular/core';
+
+/** A link target available on the page currently open in the designer. */
+export interface PageAnchor {
+    /** Anchor value without the leading `#`, e.g. `specifications` — this is what a link stores. */
+    value: string;
+    /** Readable origin of the anchor, e.g. the section name, shown next to the value in the picker. */
+    label: string;
+}
+
+/**
+ * Seam that lets rich-text controls read the anchors of the whole page being edited.
+ *
+ * The controls live in `core`, while the page model belongs to the lazily loaded `editor` feature,
+ * so the dependency is inverted through this token — the same approach `ngv-markdown` uses for its
+ * data service. Controls inject it with `{ optional: true }` and degrade to CKEditor's own
+ * field-local anchor lookup when nothing is registered.
+ */
+export interface PageAnchorsProvider {
+    /** Anchors in page order. */
+    getAnchors(): PageAnchor[];
+}
+
+export const PAGE_ANCHORS_PROVIDER = new InjectionToken<PageAnchorsProvider>('PAGE_ANCHORS_PROVIDER');

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/services/page-anchors.provider.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/services/page-anchors.provider.ts
@@ -22,3 +22,35 @@ export interface PageAnchorsProvider {
 }
 
 export const PAGE_ANCHORS_PROVIDER = new InjectionToken<PageAnchorsProvider>('PAGE_ANCHORS_PROVIDER');
+
+/**
+ * The provider of the editor route that is currently active, or `null` outside it.
+ *
+ * The rich-text controls patch the global CKEditor namespace, which outlives the editor route, while
+ * the provider is route scoped and replaced on every visit. Routing it through this registry keeps
+ * the patches reading the live service — and, once the route is gone, nothing at all, so an editor
+ * opened elsewhere falls back to CKEditor's own field-local anchors instead of listing the anchors
+ * of the page that happened to be open last.
+ */
+let activeProvider: PageAnchorsProvider | null = null;
+
+/** Called by the route scoped provider when it is created. */
+export function setActivePageAnchorsProvider(provider: PageAnchorsProvider): void {
+    activeProvider = provider;
+}
+
+/**
+ * Called by the route scoped provider when it is destroyed. Navigating between pages creates the new
+ * provider before the old one is torn down, so a provider that is no longer the active one is
+ * ignored rather than clearing its successor.
+ */
+export function clearActivePageAnchorsProvider(provider: PageAnchorsProvider): void {
+    if (activeProvider === provider) {
+        activeProvider = null;
+    }
+}
+
+/** Anchors of the page currently being edited, empty outside the editor route. */
+export function getActivePageAnchors(): PageAnchor[] {
+    return activeProvider?.getAnchors() || [];
+}

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/services/page-anchors.provider.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/core/services/page-anchors.provider.ts
@@ -27,22 +27,22 @@ export const PAGE_ANCHORS_PROVIDER = new InjectionToken<PageAnchorsProvider>('PA
  * The provider of the editor route that is currently active, or `null` outside it.
  *
  * The rich-text controls patch the global CKEditor namespace, which outlives the editor route, while
- * the provider is route scoped and replaced on every visit. Routing it through this registry keeps
- * the patches reading the live service — and, once the route is gone, nothing at all, so an editor
- * opened elsewhere falls back to CKEditor's own field-local anchors instead of listing the anchors
- * of the page that happened to be open last.
+ * the provider is route scoped. Routing it through this registry keeps the patches reading the live
+ * service — and, once the route is gone, nothing at all, so an editor opened elsewhere falls back to
+ * CKEditor's own field-local anchors instead of listing the anchors of the page that happened to be
+ * open last.
  */
 let activeProvider: PageAnchorsProvider | null = null;
 
-/** Called by the route scoped provider when it is created. */
+/** Called by the editor route's component when it is created. */
 export function setActivePageAnchorsProvider(provider: PageAnchorsProvider): void {
     activeProvider = provider;
 }
 
 /**
- * Called by the route scoped provider when it is destroyed. Navigating between pages creates the new
- * provider before the old one is torn down, so a provider that is no longer the active one is
- * ignored rather than clearing its successor.
+ * Called by the editor route's component when it is destroyed. Should a future route ever be created
+ * before its predecessor is torn down, a provider that is no longer the active one is ignored rather
+ * than clearing its successor.
  */
 export function clearActivePageAnchorsProvider(provider: PageAnchorsProvider): void {
     if (activeProvider === provider) {

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/components/edit-section/edit-section.component.html
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/components/edit-section/edit-section.component.html
@@ -24,6 +24,10 @@
                 <span [cdkCopyToClipboard]="vm.model.id">
                     ID: {{ vm.model.id }}
                     <app-icon [smallSize]="true" [inline]="true">content_copy</app-icon>
+                </span><br />
+                <span [cdkCopyToClipboard]="'#' + vm.anchor" title="Link to this section from a rich text field">
+                    Anchor: #{{ vm.anchor }}
+                    <app-icon [smallSize]="true" [inline]="true">content_copy</app-icon>
                 </span>
               </div>
             }

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/components/template-editor-host/template-editor-host.component.spec.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/components/template-editor-host/template-editor-host.component.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PAGE_ANCHORS_PROVIDER, PageAnchor, getActivePageAnchors } from '@core/services';
+
+import { TemplateEditorHostComponent } from './template-editor-host.component';
+
+const pageAnchors: PageAnchor[] = [{ value: 'specifications', label: 'Specifications' }];
+
+describe('TemplateEditorHostComponent', () => {
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [{ provide: PAGE_ANCHORS_PROVIDER, useValue: { getAnchors: () => pageAnchors } }]
+        });
+
+        // The host only exists to lay the editor out; the anchors registration is what is under test.
+        TestBed.overrideComponent(TemplateEditorHostComponent, { set: { template: '', imports: [] } });
+    });
+
+    it('publishes the page anchors while the editor route is on screen', () => {
+        TestBed.createComponent(TemplateEditorHostComponent);
+
+        expect(getActivePageAnchors()).toEqual(pageAnchors);
+    });
+
+    it('takes them down again when the route is left', () => {
+        const fixture = TestBed.createComponent(TemplateEditorHostComponent);
+
+        // Leaving /pages destroys the routed component — unlike the route injector, which the router
+        // keeps alive for the whole application, so a service ngOnDestroy would never run.
+        fixture.destroy();
+
+        expect(getActivePageAnchors()).toEqual([]);
+    });
+});

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/components/template-editor-host/template-editor-host.component.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/components/template-editor-host/template-editor-host.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { TemplateEditorComponent } from '@editor/components/template-editor/template-editor.component';
+import { PAGE_ANCHORS_PROVIDER, clearActivePageAnchorsProvider, setActivePageAnchorsProvider } from '@core/services';
 
 @Component({
     selector: 'app-template-editor-host',
@@ -9,5 +10,24 @@ import { TemplateEditorComponent } from '@editor/components/template-editor/temp
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [RouterOutlet, TemplateEditorComponent]
 })
-export class TemplateEditorHostComponent {
+export class TemplateEditorHostComponent implements OnDestroy {
+
+    private readonly pageAnchors = inject(PAGE_ANCHORS_PROVIDER);
+
+    /**
+     * Publishes the page anchors to the rich-text controls for as long as the editor is on screen.
+     *
+     * The registration is bound to this component rather than to the service that fills it, because
+     * the route `providers` live in an `EnvironmentInjector` the router keeps alive for the whole
+     * application unless `withExperimentalAutoCleanupInjectors` is enabled — a service `ngOnDestroy`
+     * would never run. This component is created and destroyed with the route itself, so leaving the
+     * editor really does take the anchors down with it.
+     */
+    constructor() {
+        setActivePageAnchorsProvider(this.pageAnchors);
+    }
+
+    ngOnDestroy(): void {
+        clearActivePageAnchorsProvider(this.pageAnchors);
+    }
 }

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/editor.routes.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/editor.routes.ts
@@ -8,6 +8,8 @@ import {
     EditSectionComponent,
     ToolbarHostComponent
 } from '@editor/components';
+import { PAGE_ANCHORS_PROVIDER } from '@core/services';
+import { PageAnchorsService } from '@editor/services';
 import { EditorModuleInfo } from '@models/modules';
 import { EditorFeatureName, editorReducers, EFFECTS } from './store';
 
@@ -17,7 +19,11 @@ export const EDITOR_ROUTES: Routes = [
         component: TemplateEditorHostComponent,
         providers: [
             provideState(EditorFeatureName, editorReducers),
-            provideEffects(EFFECTS)
+            provideEffects(EFFECTS),
+            // Rich-text controls resolve page-wide anchors through this seam (VCST-5704). Registered
+            // here so it can read the editor feature state provided just above.
+            PageAnchorsService,
+            { provide: PAGE_ANCHORS_PROVIDER, useExisting: PageAnchorsService }
         ],
         data: { module: EditorModuleInfo.name, toolbar: ToolbarHostComponent },
         children: [

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/helpers/anchors.helpers.spec.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/helpers/anchors.helpers.spec.ts
@@ -1,0 +1,155 @@
+import { collectPageAnchors, getItemAnchor } from './anchors.helpers';
+import { createBlock, createSchema, createSection, createTemplate } from '@app/testing';
+import { SectionsSchemasList } from '@editor/models';
+
+const noSchemas: SectionsSchemasList = {};
+
+function collect(template: Parameters<typeof collectPageAnchors>[0], schemas: SectionsSchemasList = noSchemas) {
+    return collectPageAnchors(template, schemas, noSchemas);
+}
+
+function values(template: Parameters<typeof collectPageAnchors>[0]) {
+    return collect(template).map(anchor => anchor.value);
+}
+
+// ── collectPageAnchors ─────────────────────────────────────────────
+
+describe('collectPageAnchors', () => {
+    it('returns an empty list for a missing template', () => {
+        expect(collect(null)).toEqual([]);
+    });
+
+    it('returns section ids in page order', () => {
+        const template = createTemplate({
+            content: [createSection({ id: 'hero1' }), createSection({ id: 'text2' })]
+        });
+
+        expect(values(template)).toEqual(['hero1', 'text2']);
+    });
+
+    it('prefers the anchor setting over the generated id', () => {
+        const template = createTemplate({
+            content: [createSection({ id: 'text2', anchor: 'Technical Specifications' } as never)]
+        });
+
+        expect(values(template)).toEqual(['technical-specifications']);
+    });
+
+    it('lists block anchors right after their section', () => {
+        const template = createTemplate({
+            content: [createSection({ id: 'hero1', blocks: [createBlock({ id: 'title3' })] })]
+        });
+
+        expect(values(template)).toEqual(['hero1', 'title3']);
+    });
+
+    it('skips hidden sections and blocks because they are not rendered', () => {
+        const template = createTemplate({
+            content: [
+                createSection({ id: 'hidden1', hidden: true }),
+                createSection({ id: 'hero1', blocks: [createBlock({ id: 'hidden2', hidden: true })] })
+            ]
+        });
+
+        expect(values(template)).toEqual(['hero1']);
+    });
+
+    it('collects in-text anchors created by the CKEditor Anchor button', () => {
+        const template = createTemplate({
+            content: [createSection({ id: 'text2', content: '<p><a name="chapter-one">One</a></p>' } as never)]
+        });
+
+        expect(values(template)).toEqual(['text2', 'chapter-one']);
+    });
+
+    it('collects element ids authored through the source view', () => {
+        const template = createTemplate({
+            content: [createSection({ id: 'text2', content: '<h2 id="pricing">Pricing</h2>' } as never)]
+        });
+
+        expect(values(template)).toEqual(['text2', 'pricing']);
+    });
+
+    it('finds rich text nested in list and object settings', () => {
+        const template = createTemplate({
+            content: [createSection({
+                id: 'faq1',
+                items: [{ answer: '<p id="shipping">Ships in a day</p>' }],
+                footer: { note: { html: '<a name="legal">Legal</a>' } }
+            } as never)]
+        });
+
+        expect(values(template)).toEqual(['faq1', 'shipping', 'legal']);
+    });
+
+    it('keeps every anchor once', () => {
+        const template = createTemplate({
+            content: [
+                createSection({ id: 'text2', content: '<p id="dup"></p><p id="dup"></p>' } as never),
+                createSection({ id: 'text3', content: '<p id="dup"></p>' } as never)
+            ]
+        });
+
+        expect(values(template)).toEqual(['text2', 'dup', 'text3']);
+    });
+
+    it('ignores plain text settings', () => {
+        const template = createTemplate({
+            content: [createSection({ id: 'hero1', title: 'No markup here' } as never)]
+        });
+
+        expect(values(template)).toEqual(['hero1']);
+    });
+});
+
+// ── labels ─────────────────────────────────────────────────────────
+
+describe('collectPageAnchors labels', () => {
+    it('names an anchor after the schema displayField the theme declares', () => {
+        const template = createTemplate({
+            content: [createSection({ id: 'imagexun', type: 'image', name: 'Hero image' } as never)]
+        });
+        const schemas = <SectionsSchemasList>{ image: createSchema({ type: 'image', name: 'Image', displayField: 'name' }) };
+
+        expect(collect(template, schemas)).toEqual([{ value: 'imagexun', label: 'Hero image' }]);
+    });
+
+    it('falls back to the schema name when the item was never named', () => {
+        const template = createTemplate({ content: [createSection({ id: 'imagexun', type: 'image' })] });
+        const schemas = <SectionsSchemasList>{ image: createSchema({ type: 'image', name: 'Image', displayField: 'name' }) };
+
+        expect(collect(template, schemas)).toEqual([{ value: 'imagexun', label: 'Image' }]);
+    });
+
+    it('labels an in-text anchor with the section it lives in', () => {
+        const template = createTemplate({
+            content: [createSection({ id: 'text2', type: 'text', name: 'Intro', content: '<a name="chapter">C</a>' } as never)]
+        });
+        const schemas = <SectionsSchemasList>{ text: createSchema({ type: 'text', name: 'Text', displayField: 'name' }) };
+
+        expect(collect(template, schemas)).toEqual([
+            { value: 'text2', label: 'Intro' },
+            { value: 'chapter', label: 'Intro' }
+        ]);
+    });
+});
+
+// ── getItemAnchor ──────────────────────────────────────────────────
+
+describe('getItemAnchor', () => {
+    it('falls back to the id when no anchor is set', () => {
+        expect(getItemAnchor(createSection({ id: 'hero1' }))).toBe('hero1');
+    });
+
+    it('falls back to the id when the anchor is blank', () => {
+        expect(getItemAnchor(createSection({ id: 'hero1', anchor: '   ' } as never))).toBe('hero1');
+    });
+
+    it('slugifies the authored anchor so it is valid in a hash link', () => {
+        expect(getItemAnchor(createSection({ id: 'hero1', anchor: 'Back To Top!' } as never))).toBe('back-to-top');
+    });
+
+    it('falls back to the id when the anchor slugifies to nothing', () => {
+        expect(getItemAnchor(createSection({ id: 'hero1', anchor: 'Спецификация' } as never))).toBe('hero1');
+    });
+});

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/helpers/anchors.helpers.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/helpers/anchors.helpers.ts
@@ -1,0 +1,119 @@
+import { appHelpers } from '@integration/helpers';
+import { PageAnchor } from '@core/services';
+import { SectionModel, TemplateModel } from '@models/document';
+import { SectionsSchemasList } from '@editor/models';
+
+import { getSectionName } from './editor.helpers';
+
+/**
+ * Well-known setting id a theme can declare (usually in `shared/_sections.json`) to let a content
+ * manager give a section a readable anchor instead of the generated section id.
+ */
+export const ANCHOR_SETTING_ID = 'anchor';
+
+/**
+ * Collects every anchor a link in a rich-text field can target on the page being edited, in page
+ * order and without duplicates.
+ *
+ * CKEditor only knows the anchors of the field it is attached to, which makes cross-section
+ * navigation (tables of contents, jump links, "back to top") impossible to build from the UI —
+ * see VCST-5704. Walking the page model instead gives the same list the storefront will render.
+ *
+ * Every anchor carries the name of the item it belongs to, so the picker can show
+ * "Hero image (imagexun)" instead of a bare generated id.
+ */
+export function collectPageAnchors(
+    template: TemplateModel | null | undefined,
+    sectionsSchemas: SectionsSchemasList,
+    blocksSchemas: SectionsSchemasList
+): PageAnchor[] {
+    const result: PageAnchor[] = [];
+
+    // Hidden items are not rendered, so their anchors do not exist on the page.
+    const visible = (item: SectionModel) => !item.hidden;
+
+    for (const section of (template?.content || []).filter(visible)) {
+        collectItemAnchors(section, sectionsSchemas, result);
+
+        for (const block of (section.blocks || []).filter(visible)) {
+            // A block type may be described either as a block or as a section schema.
+            collectItemAnchors(block, blocksSchemas[block.type] ? blocksSchemas : sectionsSchemas, result);
+        }
+    }
+
+    return result;
+}
+
+function collectItemAnchors(item: SectionModel, schemas: SectionsSchemasList, result: PageAnchor[]): void {
+    const label = getSectionName(item, schemas?.[item.type] || null);
+
+    addAnchor(result, getItemAnchor(item), label);
+
+    // `blocks` is walked by the caller, so it is left out to avoid parsing every block twice.
+    const settings = Object.entries(item).filter(([key]) => key !== 'blocks').map(([, value]) => value);
+    for (const anchor of collectValueAnchors(settings)) {
+        addAnchor(result, anchor, label);
+    }
+}
+
+/**
+ * The anchor the storefront renders for a section or block: the readable one a content manager
+ * typed, falling back to the generated id that is always present in the markup.
+ */
+export function getItemAnchor(item: SectionModel): string {
+    const custom = item[ANCHOR_SETTING_ID];
+    if (typeof custom === 'string' && custom.trim()) {
+        // Slugifying drops everything outside `[\w\s-]`, so a value made only of such characters
+        // (Cyrillic, for one) collapses to an empty string — the generated id still works then.
+        const slug = appHelpers.generateAnchor(custom);
+        if (slug) {
+            return slug;
+        }
+    }
+    return '' + (item.id || '');
+}
+
+/**
+ * Rich text can sit anywhere in a setting value — directly on the section, inside an `object`
+ * control or inside every item of a `list` control — so the whole value tree is walked.
+ */
+function collectValueAnchors(value: unknown): string[] {
+    if (typeof value === 'string') {
+        return extractHtmlAnchors(value);
+    }
+    if (Array.isArray(value)) {
+        return value.flatMap(collectValueAnchors);
+    }
+    if (value && typeof value === 'object') {
+        return Object.values(value).flatMap(collectValueAnchors);
+    }
+    return [];
+}
+
+/**
+ * In-text anchors: the ones the CKEditor `Anchor` button produces (`<a name="...">`) and any
+ * element the author gave an id to through the source view.
+ */
+function extractHtmlAnchors(html: string): string[] {
+    // Cheap guard — most settings hold plain text and never need parsing.
+    if (!html || html.indexOf('<') === -1 || typeof DOMParser === 'undefined') {
+        return [];
+    }
+
+    const parsed = new DOMParser().parseFromString(html, 'text/html');
+
+    return [
+        ...readAttribute(parsed.querySelectorAll('a[name]'), 'name'),
+        ...readAttribute(parsed.querySelectorAll('[id]'), 'id')
+    ];
+}
+
+function readAttribute(elements: ArrayLike<Element>, attribute: string): string[] {
+    return Array.from(elements).map(element => (element.getAttribute(attribute) || '').trim());
+}
+
+function addAnchor(result: PageAnchor[], value: string, label: string): void {
+    if (value && !result.some(anchor => anchor.value === value)) {
+        result.push({ value, label });
+    }
+}

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/helpers/index.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/helpers/index.ts
@@ -1,3 +1,4 @@
 export * as helpers from './editor.helpers';
+export * as anchorHelpers from './anchors.helpers';
 export * from './context-menu.helper';
 export * as clipboardHelpers from './clipboard.helpers';

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/services/index.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/services/index.ts
@@ -1,2 +1,3 @@
 export * from './schemas.service';
 export * from './templates.service';
+export * from './page-anchors.service';

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/services/page-anchors.service.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/services/page-anchors.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
 
-import { PageAnchor, PageAnchorsProvider } from '@core/services';
+import { PageAnchor, PageAnchorsProvider, clearActivePageAnchorsProvider } from '@core/services';
 import { BuilderState } from '@editor/store/state';
 import * as selectors from '@editor/store/selectors';
 
@@ -13,7 +13,7 @@ import * as selectors from '@editor/store/selectors';
  * only exists once that route is activated.
  */
 @Injectable()
-export class PageAnchorsService implements PageAnchorsProvider {
+export class PageAnchorsService implements PageAnchorsProvider, OnDestroy {
 
     private readonly store$ = inject(Store<BuilderState>);
 
@@ -21,5 +21,14 @@ export class PageAnchorsService implements PageAnchorsProvider {
 
     getAnchors(): PageAnchor[] {
         return this.anchors();
+    }
+
+    /**
+     * Rich-text controls reach this service through a registry that survives the editor route, so it
+     * has to step down explicitly — otherwise a link dialog opened in another module, a theme for
+     * instance, would keep listing the anchors of the page that was open last instead of its own.
+     */
+    ngOnDestroy(): void {
+        clearActivePageAnchorsProvider(this);
     }
 }

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/services/page-anchors.service.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/services/page-anchors.service.ts
@@ -1,0 +1,25 @@
+import { Injectable, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Store } from '@ngrx/store';
+
+import { PageAnchor, PageAnchorsProvider } from '@core/services';
+import { BuilderState } from '@editor/store/state';
+import * as selectors from '@editor/store/selectors';
+
+/**
+ * Publishes the anchors of the page being edited to the rich-text controls.
+ *
+ * Provided by the editor route rather than at root, because it reads the editor feature state that
+ * only exists once that route is activated.
+ */
+@Injectable()
+export class PageAnchorsService implements PageAnchorsProvider {
+
+    private readonly store$ = inject(Store<BuilderState>);
+
+    private readonly anchors = toSignal(this.store$.select(selectors.selectPageAnchors), { initialValue: <PageAnchor[]>[] });
+
+    getAnchors(): PageAnchor[] {
+        return this.anchors();
+    }
+}

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/services/page-anchors.service.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/services/page-anchors.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, OnDestroy, inject } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
 
-import { PageAnchor, PageAnchorsProvider, clearActivePageAnchorsProvider } from '@core/services';
+import { PageAnchor, PageAnchorsProvider } from '@core/services';
 import { BuilderState } from '@editor/store/state';
 import * as selectors from '@editor/store/selectors';
 
@@ -13,7 +13,7 @@ import * as selectors from '@editor/store/selectors';
  * only exists once that route is activated.
  */
 @Injectable()
-export class PageAnchorsService implements PageAnchorsProvider, OnDestroy {
+export class PageAnchorsService implements PageAnchorsProvider {
 
     private readonly store$ = inject(Store<BuilderState>);
 
@@ -21,14 +21,5 @@ export class PageAnchorsService implements PageAnchorsProvider, OnDestroy {
 
     getAnchors(): PageAnchor[] {
         return this.anchors();
-    }
-
-    /**
-     * Rich-text controls reach this service through a registry that survives the editor route, so it
-     * has to step down explicitly — otherwise a link dialog opened in another module, a theme for
-     * instance, would keep listing the anchors of the page that was open last instead of its own.
-     */
-    ngOnDestroy(): void {
-        clearActivePageAnchorsProvider(this);
     }
 }

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/store/selectors/data.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/store/selectors/data.ts
@@ -8,7 +8,7 @@ import { selectTemplateDataState, selectCurrentSectionsFilter } from './common';
 import { SectionsSchemasList } from '@editor/models';
 import { appHelpers } from '@integration/helpers';
 import { coreHelpers } from '@core/helpers';
-import { helpers } from '@editor/helpers';
+import { helpers, anchorHelpers } from '@editor/helpers';
 
 import * as fromRoute from '@shared/routing/selectors';
 import * as fromShared from '@shared/store/selectors';
@@ -252,6 +252,18 @@ export const selectGroupedSectionSchemas = createSelector(
             items: groups.find(x => x.noname)?.items || []
         }
     }
+);
+
+/**
+ * Every anchor a rich-text link can target on the page being edited — used to lift the CKEditor
+ * link dialog out of its single-field scope (VCST-5704).
+ */
+export const selectPageAnchors = createSelector(
+    selectCurrentTemplateModel,
+    selectSectionsSchemas,
+    selectBlocksSchemas,
+    (template, sectionsSchemas, blocksSchemas) =>
+        anchorHelpers.collectPageAnchors(template, sectionsSchemas, blocksSchemas)
 );
 
 export const selectRunActionContext = createSelector(

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/store/selectors/ui.ts
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/app/modules/editor/store/selectors/ui.ts
@@ -14,7 +14,7 @@ import * as fromDomain from "./domain";
 import * as fromData from "./data";
 import * as fromShared from '@shared/store';
 
-import { helpers } from "@editor/helpers";
+import { helpers, anchorHelpers } from "@editor/helpers";
 import { appHelpers } from "@integration/helpers";
 
 export const selectAddItemTitle = createSelector(
@@ -226,6 +226,9 @@ export const selectEditSectionContext = createSelector(
         blockSchema: blockContext.blockSchema,
         schema, model,
         isEditSettings: isSettings,
+        // Link target this item exposes on the rendered page, shown so a content manager can build
+        // a table of contents without guessing (VCST-5704).
+        anchor: anchorHelpers.getItemAnchor(model),
         editContext: {
           model, // current item under editing, can be block, section or settings
           block: blockContext.block, // current block or null

--- a/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/layout/external.scss
+++ b/src/VirtoCommerce.PageBuilderModule.Web/Apps/page-builder-designer/src/layout/external.scss
@@ -1,0 +1,142 @@
+@use './variables' as *;
+
+// CKEditor 4 dialogs (link, image, table, ...) are rendered into the document body, so they are
+// styled here rather than in a component.
+//
+// The skin ships `.cke_reset_all, .cke_reset_all *` with `background: transparent` and
+// `font: normal normal normal 12px Arial`, which wipes out both the arrow `@tailwindcss/forms`
+// draws on a select and the application typography. That rule is specificity (0,1,0) and the skin
+// stylesheet is injected after the bundle, so every override below is scoped under `.cke_dialog`
+// to win on specificity rather than order.
+
+// Mirrors $icons-color. Inlined because a data URI needs the hash escaped as %23.
+$cke-select-arrow: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23484848' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 8.5l4 4 4-4'/%3E%3C/svg%3E";
+
+.cke_dialog {
+    // Undo the skin's Arial 12px for text nodes, while leaving CKEditor's own icon fonts alone.
+    .cke_dialog_title,
+    .cke_dialog_ui_labeled_label,
+    .cke_dialog_ui_labeled_content,
+    .cke_dialog_tab,
+    legend,
+    label,
+    input,
+    select,
+    textarea,
+    a.cke_dialog_ui_button {
+        font-family: 'Inter', sans-serif;
+        font-size: $default-font-size;
+        line-height: 20px;
+    }
+
+    .cke_dialog_title {
+        color: $heading-color;
+        font-weight: 600;
+    }
+
+    .cke_dialog_ui_labeled_label {
+        display: block;
+        margin: 0 0 0.25rem;
+        color: $label-color;
+    }
+
+    // Every control shares the application's input look.
+    input.cke_dialog_ui_input_text,
+    input.cke_dialog_ui_input_password,
+    input.cke_dialog_ui_input_tel,
+    textarea.cke_dialog_ui_input_textarea,
+    select.cke_dialog_ui_input_select {
+        min-height: 2rem;
+        padding: 0.25rem 0.5rem;
+        border: 1px solid $controls-border-color;
+        border-radius: 0.25rem;
+        color: $form-controls-text-color;
+        background-color: #fff;
+        box-sizing: border-box;
+
+        &:hover {
+            border-color: $secondary-element-color;
+        }
+
+        // The skin focuses with a 2px border, which shifts the control by a pixel. Keep the border
+        // width and show the focus as a ring instead.
+        &:focus {
+            border: 1px solid $active-color;
+            box-shadow: 0 0 0 2px rgba(22, 101, 216, 0.16);
+        }
+    }
+
+    select.cke_dialog_ui_input_select {
+        height: 2rem;
+        line-height: 20px;
+        // Restore the arrow the reset stripped, and reserve room for it so long option labels such
+        // as "Call to Action (call-action)" never run underneath.
+        padding-right: 1.75rem;
+        background-image: url($cke-select-arrow);
+        background-repeat: no-repeat;
+        background-position: right 0.5rem center;
+        background-size: 1rem 1rem;
+        appearance: none;
+        cursor: pointer;
+    }
+
+    // The skin lays the select wrapper out as a table, which shrinks it to its content and leaves
+    // the field far narrower than the row it sits in.
+    div.cke_dialog_ui_input_select {
+        display: block;
+        width: 100%;
+    }
+
+    .cke_dialog_ui_hbox_first,
+    .cke_dialog_ui_hbox_child,
+    .cke_dialog_ui_hbox_last {
+        padding-right: 0.75rem;
+        vertical-align: top;
+
+        &:last-child {
+            padding-right: 0;
+        }
+    }
+
+    .cke_dialog_ui_vbox_child {
+        padding-top: 0.75rem;
+    }
+
+    fieldset {
+        margin-top: 0.5rem;
+        padding: 0.75rem;
+        border: 1px solid $border-color;
+        border-radius: 0.25rem;
+
+        legend {
+            padding: 0 0.25rem;
+            color: $label-color;
+        }
+    }
+
+    // Footer buttons: primary action in the application accent, the rest neutral.
+    a.cke_dialog_ui_button {
+        padding: 0.25rem 0.875rem;
+        border: 1px solid $controls-border-color;
+        border-radius: 0.25rem;
+        color: $form-controls-text-color;
+        background: #fff;
+        box-shadow: none;
+        text-shadow: none;
+
+        &:hover {
+            background: $hover-color;
+        }
+    }
+
+    a.cke_dialog_ui_button_ok {
+        border-color: $active-color;
+        color: #fff;
+        background: $active-color;
+
+        &:hover {
+            border-color: #1257bb;
+            background: #1257bb;
+        }
+    }
+}


### PR DESCRIPTION
## Description

CKEditor lists only the anchors of the field its link dialog was opened from, so a content manager could not build a table of contents or a jump link targeting another section. The option cannot be configured away either: "Link to anchor in the text" is hardcoded in the link plugin dialog definition and is unaffected by removePlugins: "anchor", which only drops the toolbar button.

Collect the anchors of the whole page from the editor model — the anchor setting of each section and block, falling back to the generated id, plus in-text <a name> anchors and ids authored through the source view — and feed them to the dialog by overriding CKEDITOR.plugins.link.getEditorAnchors. The picker lists them as "<item name> (<anchor>)", keeps an anchor that is no longer on the page selected instead of silently clearing the link, and hides the now empty "By Element Id" list so the picker uses the full row.

Rich-text controls live in core while the page model belongs to the lazily loaded editor feature, so the list is passed through a PAGE_ANCHORS_PROVIDER token registered by the editor route. The edit panel also shows the anchor of the current section, with a copy button.

<img width="481" height="391" alt="2026-08-14_13-04-38" src="https://github.com/user-attachments/assets/05f328bf-3379-460a-b652-d9c5c7cbbf42" />

<img width="488" height="378" alt="2026-08-14_13-05-00" src="https://github.com/user-attachments/assets/73b4b11c-6ecf-4260-839d-29f841f01a74" />

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5704
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PageBuilderModule_3.1022.0-pr-160-a39f.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patches the global CKEditor link plugin and dialog so rich-text links can target any page anchor. Behavior is scoped to the editor route with a field-local fallback, but a global override can affect other CKEditor instances if the active-provider registry is wrong.
> 
> **Overview**
> CKEditor’s link dialog only listed anchors in the field it was opened from, so tables of contents and jump links across sections were not possible from the UI.
> 
> The designer now collects every visible page target — the well-known `anchor` setting (slugified, else the generated id), in-text `<a name>` anchors, and element ids in HTML — and feeds that list into the link picker as `#anchor` entries labeled `<item name> (anchor)`. Hidden items are omitted. Missing/stale anchors stay selected instead of being cleared on save. The empty **By Element Id** list is hidden so the picker spans the dialog.
> 
> The list is published through a route-scoped `PAGE_ANCHORS_PROVIDER` so core rich-text controls do not depend on the editor feature; leaving the editor restores CKEditor’s field-local lookup. The section/block panel shows the current anchor with a copy button. Themes must render the matching element id. CKEditor dialogs also get application-aligned styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a39ff30dfbde208ec96eef856a867aee7f23fdd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->